### PR TITLE
feat: Added morphMap Relations for UGC models from wm-package

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Relation::morphMap([
+            'App\\Models\\UgcPoi' => \Wm\WmPackage\Models\UgcPoi::class,
+            'App\\Models\\UgcTrack' => \Wm\WmPackage\Models\UgcTrack::class,
+        ]);
     }
 }


### PR DESCRIPTION
Legata a PR [75](https://github.com/webmappsrl/wm-package/pull/75) mapping necessario per accedere al modello tramite $media->model nel MediaObserver. Senza questo la relazione va a cercare il modello nel namespace App\Models del progetto principale. Con questo mapping, il model_type nella tabella media viene comunque salvato con namespace App\Models ma quando andiamo a recuperare il ->model ci restituisce quello del wm package.