### PR TITLE
feat(nova): ✨ add trait to hide 'app' field from index OC:6092

### DIFF
--- a/app/Nova/Traits/HidesAppFromIndexTrait.php
+++ b/app/Nova/Traits/HidesAppFromIndexTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Nova\Traits;
+
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+trait HidesAppFromIndexTrait
+{
+    public function fields(NovaRequest $request): array
+    {
+        $fields = parent::fields($request);
+
+        foreach ($fields as $field) {
+            if ($field->attribute === 'app') {
+                $field->hideFromIndex();
+            }
+        }
+
+        return $fields;
+    }
+}

--- a/app/Nova/UgcPoi.php
+++ b/app/Nova/UgcPoi.php
@@ -2,6 +2,10 @@
 
 namespace App\Nova;
 
+use App\Nova\Traits\HidesAppFromIndexTrait;
 use Wm\WmPackage\Nova\UgcPoi as WmNovaUgcPoi;
 
-class UgcPoi extends WmNovaUgcPoi {}
+class UgcPoi extends WmNovaUgcPoi
+{
+    use HidesAppFromIndexTrait;
+}

--- a/app/Nova/UgcTrack.php
+++ b/app/Nova/UgcTrack.php
@@ -2,6 +2,10 @@
 
 namespace App\Nova;
 
+use App\Nova\Traits\HidesAppFromIndexTrait;
 use Wm\WmPackage\Nova\UgcTrack as WmNovaUgcTrack;
 
-class UgcTrack extends WmNovaUgcTrack {}
+class UgcTrack extends WmNovaUgcTrack
+{
+    use HidesAppFromIndexTrait;
+}


### PR DESCRIPTION
- Introduced `HidesAppFromIndexTrait` to streamline the process of hiding the 'app' attribute from index views in Nova resources.
- Updated `UgcPoi` and `UgcTrack` classes to implement the new trait, ensuring consistent application of this behavior across these resources.
