### PR TITLE
feat(nova): ✨ add FiltersUsersByRoleTrait to EcTrack and Layer classes OC:6043

### DIFF
--- a/app/Nova/EcTrack.php
+++ b/app/Nova/EcTrack.php
@@ -2,6 +2,10 @@
 
 namespace App\Nova;
 
+use App\Nova\Traits\FiltersUsersByRoleTrait;
 use Wm\WmPackage\Nova\EcTrack as WmNovaEcTrack;
 
-class EcTrack extends WmNovaEcTrack {}
+class EcTrack extends WmNovaEcTrack
+{
+    use FiltersUsersByRoleTrait;
+}

--- a/app/Nova/Layer.php
+++ b/app/Nova/Layer.php
@@ -2,6 +2,7 @@
 
 namespace App\Nova;
 
+use App\Nova\Traits\FiltersUsersByRoleTrait;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
@@ -11,6 +12,8 @@ use Wm\WmPackage\Nova\Layer as WmNovaLayer;
 
 class Layer extends WmNovaLayer
 {
+    use FiltersUsersByRoleTrait;
+
     public static function indexQuery(NovaRequest $request, $query)
     {
         $user = Auth::user();

--- a/app/Nova/Traits/FiltersUsersByRoleTrait.php
+++ b/app/Nova/Traits/FiltersUsersByRoleTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Nova\Traits;
+
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+trait FiltersUsersByRoleTrait
+{
+    /**
+     * Limit relatable users to Administrators and Validators when current user is an Administrator.
+     */
+    public static function relatableUsers(NovaRequest $request, $query)
+    {
+        $currentUser = $request->user();
+
+        if ($currentUser && $currentUser->hasRole('Administrator')) {
+            return $query->role(['Administrator', 'Validator']);
+        }
+
+        return $query;
+    }
+}

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -37,9 +37,12 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                 MenuSection::dashboard(Main::class)->icon('chart-bar'),
 
                 MenuSection::make(' ', [
-                    MenuItem::resource(App::class),
-                    MenuItem::resource(NovaUser::class),
-                    MenuItem::resource(Media::class),
+                    MenuItem::resource(App::class)
+                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
+                    MenuItem::resource(NovaUser::class)
+                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
+                    MenuItem::resource(Media::class)
+                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
                 ])->icon(''),
 
                 MenuSection::make('UGC', [
@@ -58,11 +61,11 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                 // ])->icon('document'),
 
                 MenuSection::make('Tools', [
-                    MenuItem::externalLink('Horizon', url('/horizon'))->openInNewTab(),
-                    MenuItem::externalLink('Telescope', url('/telescope'))->openInNewTab(),
-                ])->icon('briefcase')->canSee(function (Request $request) {
-                    return $request->user()->email === 'team@webmapp.it';
-                }),
+                    MenuItem::externalLink('Horizon', url('/horizon'))->openInNewTab()
+                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
+                    MenuItem::externalLink('Telescope', url('/telescope'))->openInNewTab()
+                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
+                ])->icon('briefcase'),
             ];
         });
     }

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -37,12 +37,9 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                 MenuSection::dashboard(Main::class)->icon('chart-bar'),
 
                 MenuSection::make(' ', [
-                    MenuItem::resource(App::class)
-                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
-                    MenuItem::resource(NovaUser::class)
-                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
-                    MenuItem::resource(Media::class)
-                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
+                    MenuItem::resource(App::class),
+                    MenuItem::resource(NovaUser::class),
+                    MenuItem::resource(Media::class),
                 ])->icon(''),
 
                 MenuSection::make('UGC', [
@@ -61,11 +58,11 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                 // ])->icon('document'),
 
                 MenuSection::make('Tools', [
-                    MenuItem::externalLink('Horizon', url('/horizon'))->openInNewTab()
-                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
-                    MenuItem::externalLink('Telescope', url('/telescope'))->openInNewTab()
-                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
-                ])->icon('briefcase'),
+                    MenuItem::externalLink('Horizon', url('/horizon'))->openInNewTab(),
+                    MenuItem::externalLink('Telescope', url('/telescope'))->openInNewTab(),
+                ])->icon('briefcase')->canSee(function (Request $request) {
+                    return $request->user()->email === 'team@webmapp.it';
+                }),
             ];
         });
     }


### PR DESCRIPTION
- Introduced `FiltersUsersByRoleTrait` to limit relatable users based on roles
- Applied the trait to both `EcTrack` and `Layer` classes in the Nova package
- Ensures that when the current user is an Administrator, only users with the roles of 'Administrator' and 'Validator' are relatable
- Enhances role-based user filtering capabilities in the application
