### PR TITLE
feat(nova): ✨ add role-based visibility for menu items OC: 6041

### DIFF
--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -65,9 +65,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                         ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
                     MenuItem::externalLink('Telescope', url('/telescope'))->openInNewTab()
                         ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
-                ])->icon('briefcase')->canSee(function (Request $request) {
-                    return $request->user()->email === 'team@webmapp.it';
-                }),
+                ])->icon('briefcase'),
             ];
         });
     }

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -37,9 +37,12 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                 MenuSection::dashboard(Main::class)->icon('chart-bar'),
 
                 MenuSection::make(' ', [
-                    MenuItem::resource(App::class),
-                    MenuItem::resource(NovaUser::class),
-                    MenuItem::resource(Media::class),
+                    MenuItem::resource(App::class)
+                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')), ,
+                    MenuItem::resource(NovaUser::class)
+                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
+                    MenuItem::resource(Media::class)
+                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
                 ])->icon(''),
 
                 MenuSection::make('UGC', [
@@ -58,8 +61,10 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                 // ])->icon('document'),
 
                 MenuSection::make('Tools', [
-                    MenuItem::externalLink('Horizon', url('/horizon'))->openInNewTab(),
-                    MenuItem::externalLink('Telescope', url('/telescope'))->openInNewTab(),
+                    MenuItem::externalLink('Horizon', url('/horizon'))->openInNewTab()
+                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
+                    MenuItem::externalLink('Telescope', url('/telescope'))->openInNewTab()
+                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
                 ])->icon('briefcase')->canSee(function (Request $request) {
                     return $request->user()->email === 'team@webmapp.it';
                 }),

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -38,7 +38,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
 
                 MenuSection::make(' ', [
                     MenuItem::resource(App::class)
-                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')), ,
+                        ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
                     MenuItem::resource(NovaUser::class)
                         ->canSee(fn (Request $request) => $request->user()->hasRole('Administrator')),
                     MenuItem::resource(Media::class)


### PR DESCRIPTION
- Implement role-based visibility for menu items in the Nova service provider.
- Restrict access to 'App', 'NovaUser', and 'Media' resources to users with the 'Administrator' role.
- Ensure external links 'Horizon' and 'Telescope' are also restricted to 'Administrator' role.
- Maintain existing email-based access control for the 'Tools' menu section.
