### PR TITLE
feat(commands): ✨ add command to fix layer names OC 6217

### DIFF
--- a/app/Console/Commands/FixLayerNamesCommand.php
+++ b/app/Console/Commands/FixLayerNamesCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Wm\WmPackage\Models\Layer;
+
+class FixLayerNamesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'fix:layer-names';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rename layer names to the correct format';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $allLayers = Layer::all();
+        $renamedLayers = 0;
+
+        foreach ($allLayers as $layer) {
+            $rawName = $layer->getRawOriginal('name');
+            $nameData = json_decode($rawName, true);
+
+            if (str_starts_with($nameData['it'], 'Cammini -')) {
+                $oldName = $nameData['it'];
+                $newName = preg_replace('/^Cammini -\s*/', '', $oldName);
+                $nameData['it'] = $newName;
+
+                $layer->name = $nameData;
+                $layer->saveQuietly();
+
+                $this->line("Layer ID {$layer->id}: '{$oldName}' → '{$newName}'");
+                $renamedLayers++;
+            }
+        }
+
+        $this->info('Operation completed successfully');
+        $this->info("Layer renamed correctly: {$renamedLayers}".' on '.$allLayers->count());
+    }
+}


### PR DESCRIPTION
- Introduced a new console command `fix:layer-names` to rename layer names to the correct format.
- The command scans all layers and updates names starting with "Cammini -" by removing the prefix.
- Utilizes the `Layer` model to access and modify layer data efficiently.
- Outputs the number of layers renamed and provides feedback for each change to the console.
- Enhances data consistency by standardizing layer names across the application.
