### PR TITLE
feat(models): ✨ add EcTrack and Layer models oc:6608

### DIFF
--- a/app/Http/Controllers/LayerFeatureController.php
+++ b/app/Http/Controllers/LayerFeatureController.php
@@ -8,12 +8,9 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Wm\WmPackage\Models\Layer;
 use Wm\WmPackage\Nova\Fields\LayerFeatures\Http\Controllers\LayerFeatureController as WmLayerFeatureController;
-use Wm\WmPackage\Services\Models\LayerService;
-use Wm\WmPackage\Services\PBFGeneratorService;
+
 class LayerFeatureController extends WmLayerFeatureController
 {
-
-
     public function getFeatures(Request $request, $layerId): JsonResponse
     {
         try {

--- a/app/Models/EcTrack.php
+++ b/app/Models/EcTrack.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Support\Facades\Auth;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\EcTrack as WmEcTrack;
+
+class EcTrack extends WmEcTrack
+{
+    /**
+     * Boot the model and register events.
+     */
+    protected static function booted(): void
+    {
+        parent::booted();
+
+        static::creating(function ($ecTrack) {
+            // Imposta automaticamente l'app
+            if (empty($ecTrack->app_id)) {
+                $ecTrack->app_id = App::first()->id;
+            }
+
+            // Se l'utente è un Validator, imposta automaticamente se stesso
+            /** @var \App\Models\User|null $currentUser */
+            $currentUser = Auth::user();
+            if (empty($ecTrack->user_id) && $currentUser) {
+                if ($currentUser->hasRole('Validator')) {
+                    $ecTrack->user_id = $currentUser->id;
+                }
+            }
+        });
+    }
+}

--- a/app/Models/Layer.php
+++ b/app/Models/Layer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\Layer as WmLayer;
+
+class Layer extends WmLayer
+{
+    /**
+     * Boot the model and register events.
+     */
+    protected static function booted(): void
+    {
+        parent::booted();
+
+        static::creating(function ($layer) {
+            // Set app_id automatically
+            if (empty($layer->app_id)) {
+                $layer->app_id = App::first()->id;
+            }
+        });
+    }
+}

--- a/app/Nova/EcTrack.php
+++ b/app/Nova/EcTrack.php
@@ -3,9 +3,46 @@
 namespace App\Nova;
 
 use App\Nova\Traits\FiltersUsersByRoleTrait;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\NovaRequest;
 use Wm\WmPackage\Nova\EcTrack as WmNovaEcTrack;
 
 class EcTrack extends WmNovaEcTrack
 {
     use FiltersUsersByRoleTrait;
+
+    /**
+     * The model the resource corresponds to.
+     *
+     * @var class-string<\App\Models\EcTrack>
+     */
+    public static $model = \App\Models\EcTrack::class;
+
+    /**
+     * Get the fields displayed by the resource.
+     */
+    public function fields(NovaRequest $request): array
+    {
+        $fields = parent::fields($request);
+        $currentUser = $request->user();
+
+        // Remove App field for all users
+        $fields = array_filter($fields, function ($field) {
+            return ! ($field instanceof BelongsTo && $field->attribute === 'app');
+        });
+
+        // Modify User field to be visible only to admins
+        $fields = array_map(function ($field) use ($currentUser) {
+            if ($field instanceof BelongsTo && $field->attribute === 'user') {
+                // Show User field only to admins
+                $field->canSee(function () use ($currentUser) {
+                    return $currentUser && $currentUser->hasRole('Administrator');
+                });
+            }
+
+            return $field;
+        }, $fields);
+
+        return array_values($fields);
+    }
 }

--- a/app/Nova/Layer.php
+++ b/app/Nova/Layer.php
@@ -4,6 +4,7 @@ namespace App\Nova;
 
 use App\Nova\Traits\FiltersUsersByRoleTrait;
 use Illuminate\Support\Facades\Auth;
+use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Wm\WmPackage\Nova\Layer as WmNovaLayer;
 
@@ -11,8 +12,16 @@ class Layer extends WmNovaLayer
 {
     use FiltersUsersByRoleTrait;
 
+    /**
+     * The model the resource corresponds to.
+     *
+     * @var class-string<\App\Models\Layer>
+     */
+    public static $model = \App\Models\Layer::class;
+
     public static function indexQuery(NovaRequest $request, $query)
     {
+        /** @var \App\Models\User|null $user */
         $user = Auth::user();
 
         if ($user && ! $user->hasRole('Administrator')) {
@@ -24,8 +33,26 @@ class Layer extends WmNovaLayer
 
     public function fields(NovaRequest $request): array
     {
-        return [
-            ...parent::fields($request),
-        ];
+        $fields = parent::fields($request);
+        $currentUser = $request->user();
+
+        // Remove App field for all users
+        $fields = array_filter($fields, function ($field) {
+            return ! ($field instanceof BelongsTo && $field->attribute === 'appOwner');
+        });
+
+        // Modify layerOwner field to be visible only to admins
+        $fields = array_map(function ($field) use ($currentUser) {
+            if ($field instanceof BelongsTo && $field->attribute === 'layerOwner') {
+                // Show layerOwner field only to admins
+                $field->canSee(function () use ($currentUser) {
+                    return $currentUser && $currentUser->hasRole('Administrator');
+                });
+            }
+
+            return $field;
+        }, $fields);
+
+        return array_values($fields);
     }
 }

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\LayerFeatureController;
 use App\Models\User;
 use App\Nova\App;
 use App\Nova\Dashboards\Main;
+use App\Nova\EcTrack;
+use App\Nova\Layer;
 use App\Nova\Media;
 use App\Nova\UgcPoi;
 use App\Nova\UgcTrack;
@@ -20,8 +22,6 @@ use Laravel\Nova\Menu\MenuSection;
 use Laravel\Nova\Nova;
 use Laravel\Nova\NovaApplicationServiceProvider;
 use Wm\WmPackage\Nova\EcPoi;
-use Wm\WmPackage\Nova\EcTrack;
-use Wm\WmPackage\Nova\Layer;
 
 class NovaServiceProvider extends NovaApplicationServiceProvider
 {

--- a/database/migrations/2025_10_22_123911_add_properties_to_users_table.php
+++ b/database/migrations/2025_10_22_123911_add_properties_to_users_table.php
@@ -26,4 +26,3 @@ return new class extends Migration
         });
     }
 };
-

--- a/database/migrations/2025_11_05_160332_add_user_id_index_to_layers_table.php
+++ b/database/migrations/2025_11_05_160332_add_user_id_index_to_layers_table.php
@@ -26,4 +26,3 @@ return new class extends Migration
         });
     }
 };
-


### PR DESCRIPTION
Introduce two new models, `EcTrack` and `Layer`, extending from the WmPackage models. These models include automatic setting of `app_id` during creation and specific user assignment logic for `EcTrack` when the user has the 'Validator' role.

---

feat(nova): ✨ customize EcTrack and Layer resources

Customize the Nova resources for `EcTrack` and `Layer` by extending their corresponding WmPackage Nova resources.

- For `EcTrack`, remove the `app` field for all users and make the `user` field visible only to administrators.
- For `Layer`, remove the `appOwner` field for all users and make the `layerOwner` field visible only to administrators.

Additionally, update the `NovaServiceProvider` to use the custom Nova resources, replacing the WmPackage resources.
