### PR TITLE
feat(policy): ✨ restrict validators from updating or deleting layers OC:6706

### DIFF
--- a/app/Nova/Layer.php
+++ b/app/Nova/Layer.php
@@ -17,7 +17,6 @@ class Layer extends WmNovaLayer
      *
      * @var class-string<\App\Models\Layer>
      */
-
     public static function indexQuery(NovaRequest $request, $query)
     {
         /** @var \App\Models\User|null $user */

--- a/app/Policies/LayerPolicy.php
+++ b/app/Policies/LayerPolicy.php
@@ -65,7 +65,13 @@ class LayerPolicy
      */
     public function update(User $user, Layer $layer)
     {
-        // Admins handled by before(). Users can update their own layers.
+        // Admins handled by before().
+        // Validators cannot update their own layers, only tracks associated to them.
+        if ($user->hasRole('Validator')) {
+            return false;
+        }
+
+        // Other users can update their own layers.
         return $user->id === $layer->user_id;
     }
 
@@ -76,7 +82,13 @@ class LayerPolicy
      */
     public function delete(User $user, Layer $layer)
     {
-        // Admins handled by before(). Users can delete their own layers.
+        // Admins handled by before().
+        // Validators cannot delete their own layers.
+        if ($user->hasRole('Validator')) {
+            return false;
+        }
+
+        // Other users can delete their own layers.
         return $user->id === $layer->user_id;
     }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,15 +18,15 @@ return Application::configure(basePath: dirname(__DIR__))
         //
     })
     ->withSchedule(function (Schedule $schedule) {
-        
+
         $schedule->command('telescope:prune')
-        ->weekly();
-        
+            ->weekly();
+
         $schedule->command('scout:import "Wm\WmPackage\Models\EcTrack"')
-        ->everyFifteenMinutes();
+            ->everyFifteenMinutes();
 
         $schedule->command('horizon:snapshot')
-        ->everyFiveMinutes()
-        ->description('Take Horizon snapshot');
+            ->everyFiveMinutes()
+            ->description('Take Horizon snapshot');
     })
     ->create();

--- a/database/migrations/2025_11_17_142340_zz_2025_11_06_100000_add_created_by_to_ugc_tables.php
+++ b/database/migrations/2025_11_17_142340_zz_2025_11_06_100000_add_created_by_to_ugc_tables.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     /**
      * Run the migrations.
      */
@@ -33,4 +34,3 @@ return new class extends Migration {
         });
     }
 };
-


### PR DESCRIPTION
- Updated `update` and `delete` methods in `LayerPolicy` to prevent users with the 'Validator' role from updating or deleting their own layers.
- Ensured that only users who are not Validators can update or delete their own layers while maintaining admin-level access handled by the `before()` method.
