### PR TITLE
feat(nova): ✨ restrict certain actions to administrators only OC:6715

### DIFF
--- a/app/Nova/Layer.php
+++ b/app/Nova/Layer.php
@@ -19,7 +19,6 @@ class Layer extends WmNovaLayer
      *
      * @var class-string<\App\Models\Layer>
      */
-
     public static function indexQuery(NovaRequest $request, $query)
     {
         /** @var \App\Models\User|null $user */

--- a/app/Nova/Layer.php
+++ b/app/Nova/Layer.php
@@ -6,6 +6,8 @@ use App\Nova\Traits\FiltersUsersByRoleTrait;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Wm\WmPackage\Nova\Actions\ExecuteEcTrackDataChainAction;
+use Wm\WmPackage\Nova\Actions\RegenerateLayerPbfAction;
 use Wm\WmPackage\Nova\Layer as WmNovaLayer;
 
 class Layer extends WmNovaLayer
@@ -53,5 +55,25 @@ class Layer extends WmNovaLayer
         }, $fields);
 
         return array_values($fields);
+    }
+
+    public function actions(NovaRequest $request): array
+    {
+        $actions = parent::actions($request);
+        $currentUser = $request->user();
+
+        // Filter actions to show only to administrators
+        $actions = array_map(function ($action) use ($currentUser) {
+            // Restrict RegenerateLayerPbfAction and ExecuteEcTrackDataChainAction to administrators only
+            if ($action instanceof RegenerateLayerPbfAction || $action instanceof ExecuteEcTrackDataChainAction) {
+                $action->canSee(function () use ($currentUser) {
+                    return $currentUser && $currentUser->hasRole('Administrator');
+                });
+            }
+
+            return $action;
+        }, $actions);
+
+        return $actions;
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,15 +18,15 @@ return Application::configure(basePath: dirname(__DIR__))
         //
     })
     ->withSchedule(function (Schedule $schedule) {
-        
+
         $schedule->command('telescope:prune')
-        ->weekly();
-        
+            ->weekly();
+
         $schedule->command('scout:import "Wm\WmPackage\Models\EcTrack"')
-        ->everyFifteenMinutes();
+            ->everyFifteenMinutes();
 
         $schedule->command('horizon:snapshot')
-        ->everyFiveMinutes()
-        ->description('Take Horizon snapshot');
+            ->everyFiveMinutes()
+            ->description('Take Horizon snapshot');
     })
     ->create();

--- a/database/migrations/2025_11_17_142340_zz_2025_11_06_100000_add_created_by_to_ugc_tables.php
+++ b/database/migrations/2025_11_17_142340_zz_2025_11_06_100000_add_created_by_to_ugc_tables.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     /**
      * Run the migrations.
      */
@@ -33,4 +34,3 @@ return new class extends Migration {
         });
     }
 };
-


### PR DESCRIPTION
- Added `ExecuteEcTrackDataChainAction` and `RegenerateLayerPbfAction` to the Layer class.
- Implemented a filter to ensure these actions are visible only to users with the 'Administrator' role.
- This enhances security by limiting sensitive actions to authorized personnel.
