### PR TITLE
feat(tests): ✨ add layer policy tests and helper functions OC:6729

### DIFF
--- a/tests/Feature/Helpers/LayerTestHelpers.php
+++ b/tests/Feature/Helpers/LayerTestHelpers.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\User;
+use Wm\WmPackage\Models\Layer;
+
+if (! function_exists('createUserWithRole')) {
+    function createUserWithRole(string $role): User
+    {
+        $user = User::factory()->create();
+        if ($role !== 'regular') {
+            $user->assignRole($role);
+        }
+
+        return $user;
+    }
+}
+
+if (! function_exists('createLayer')) {
+    function createLayer(?int $userId = null): Layer
+    {
+        return Layer::factory()->create($userId ? ['user_id' => $userId] : []);
+    }
+}

--- a/tests/Feature/LayerPolicyTest.php
+++ b/tests/Feature/LayerPolicyTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Gate;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Services\RolesAndPermissionsService;
+
+require_once __DIR__.'/Helpers/LayerTestHelpers.php';
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    // Seed roles and permissions
+    RolesAndPermissionsService::seedDatabase();
+
+    // Create an App for layers (required by LayerFactory)
+    if (App::count() === 0) {
+        App::factory()->create();
+    }
+});
+
+function assertGateAllows(User $user, string $ability, Layer|string $layer, bool $expected): void
+{
+    expect(Gate::forUser($user)->allows($ability, $layer))->toBe($expected);
+}
+
+// Policy tests
+test('administrators can update any layer', function () {
+    $administrator = createUserWithRole('Administrator');
+    $layer = createLayer(User::factory()->create()->id);
+
+    assertGateAllows($administrator, 'update', $layer, true);
+});
+
+test('administrators can delete any layer', function () {
+    $administrator = createUserWithRole('Administrator');
+    $layer = createLayer(User::factory()->create()->id);
+
+    assertGateAllows($administrator, 'delete', $layer, true);
+});
+
+test('administrators can create layers', function () {
+    $administrator = createUserWithRole('Administrator');
+
+    assertGateAllows($administrator, 'create', Layer::class, true);
+});
+
+test('validators cannot update their own layers', function () {
+    $validator = createUserWithRole('Validator');
+    $layer = createLayer($validator->id);
+
+    assertGateAllows($validator, 'update', $layer, false);
+});
+
+test('validators cannot update other users layers', function () {
+    $validator = createUserWithRole('Validator');
+    $layer = createLayer(User::factory()->create()->id);
+
+    assertGateAllows($validator, 'update', $layer, false);
+});
+
+test('validators cannot delete their own layers', function () {
+    $validator = createUserWithRole('Validator');
+    $layer = createLayer($validator->id);
+
+    assertGateAllows($validator, 'delete', $layer, false);
+});
+
+test('validators cannot delete other users layers', function () {
+    $validator = createUserWithRole('Validator');
+    $layer = createLayer(User::factory()->create()->id);
+
+    assertGateAllows($validator, 'delete', $layer, false);
+});
+
+test('validators cannot create layers', function () {
+    $validator = createUserWithRole('Validator');
+
+    assertGateAllows($validator, 'create', Layer::class, false);
+});
+
+test('validators can view any layer', function () {
+    $validator = createUserWithRole('Validator');
+    $layer = createLayer();
+
+    assertGateAllows($validator, 'view', $layer, true);
+});
+
+test('validators can view any layers list', function () {
+    $validator = createUserWithRole('Validator');
+
+    assertGateAllows($validator, 'viewAny', Layer::class, true);
+});


### PR DESCRIPTION
- Introduced `LayerTestHelpers.php` to encapsulate helper functions for creating users and layers in tests.
  - `createUserWithRole`: Creates a user and assigns a role, with special handling for 'regular' users.
  - `createLayer`: Creates a layer with an optional user ID.

- Implemented `LayerPolicyTest.php` to verify various user roles' abilities to interact with layers.
  - Tests cover administrator and validator roles.
  - Ensured administrators can create, update, and delete any layer.
  - Validated that validators cannot create, update, or delete layers but can view them.

- Updated the `wm-package` submodule to a new commit to incorporate recent changes.
