### PR TITLE
feat(tests): ✨ add layer policy tests and helper functions OC:6729

### DIFF
--- a/tests/Feature/Helpers/LayerTestHelpers.php
+++ b/tests/Feature/Helpers/LayerTestHelpers.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\User;
+use Wm\WmPackage\Models\Layer;
+
+if (! function_exists('createUserWithRole')) {
+    function createUserWithRole(string $role): User
+    {
+        $user = User::factory()->create();
+        if ($role !== 'regular') {
+            $user->assignRole($role);
+        }
+
+        return $user;
+    }
+}
+
+if (! function_exists('createLayer')) {
+    function createLayer(?int $userId = null): Layer
+    {
+        return Layer::factory()->create($userId ? ['user_id' => $userId] : []);
+    }
+}

--- a/tests/Feature/Helpers/LayerTestHelpers.php
+++ b/tests/Feature/Helpers/LayerTestHelpers.php
@@ -1,22 +1,39 @@
 <?php
 
+namespace Tests\Feature\Helpers;
+
 use App\Models\User;
 use Wm\WmPackage\Models\Layer;
 
-if (! function_exists('createUserWithRole')) {
-    function createUserWithRole(string $role): User
+trait LayerTestHelpers
+{
+    /**
+     * Create a user with the specified role.
+     *
+     * @param  string  $role  The role name ('Administrator', 'Validator', 'Guest')
+     */
+    protected function createUserWithRole(string $role): User
     {
         $user = User::factory()->create();
-        if ($role !== 'regular') {
-            $user->assignRole($role);
-        }
+        $user->assignRole($role);
 
         return $user;
     }
-}
 
-if (! function_exists('createLayer')) {
-    function createLayer(?int $userId = null): Layer
+    /**
+     * Create a user without any role.
+     */
+    protected function createUserWithoutRole(): User
+    {
+        return User::factory()->create();
+    }
+
+    /**
+     * Create a layer with optional user ID.
+     *
+     * @param  int|null  $userId  The user ID to associate with the layer
+     */
+    protected function createLayer(?int $userId = null): Layer
     {
         return Layer::factory()->create($userId ? ['user_id' => $userId] : []);
     }

--- a/tests/Feature/LayerPolicyTest.php
+++ b/tests/Feature/LayerPolicyTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Gate;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Services\RolesAndPermissionsService;
+
+require_once __DIR__.'/Helpers/LayerTestHelpers.php';
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    // Seed roles and permissions
+    RolesAndPermissionsService::seedDatabase();
+
+    // Create an App for layers (required by LayerFactory)
+    if (App::count() === 0) {
+        App::factory()->create();
+    }
+});
+
+function assertGateAllows(User $user, string $ability, Layer|string $layer, bool $expected): void
+{
+    expect(Gate::forUser($user)->allows($ability, $layer))->toBe($expected);
+}
+
+// Policy tests
+test('administrators can update any layer', function () {
+    $administrator = createUserWithRole('Administrator');
+    $layer = createLayer(User::factory()->create()->id);
+
+    assertGateAllows($administrator, 'update', $layer, true);
+});
+
+test('administrators can delete any layer', function () {
+    $administrator = createUserWithRole('Administrator');
+    $layer = createLayer(User::factory()->create()->id);
+
+    assertGateAllows($administrator, 'delete', $layer, true);
+});
+
+test('administrators can create layers', function () {
+    $administrator = createUserWithRole('Administrator');
+
+    assertGateAllows($administrator, 'create', Layer::class, true);
+});
+
+test('validators cannot update their own layers', function () {
+    $validator = createUserWithRole('Validator');
+    $layer = createLayer($validator->id);
+
+    assertGateAllows($validator, 'update', $layer, false);
+});
+
+test('validators cannot update other users layers', function () {
+    $validator = createUserWithRole('Validator');
+    $layer = createLayer(User::factory()->create()->id);
+
+    assertGateAllows($validator, 'update', $layer, false);
+});
+
+test('validators cannot delete their own layers', function () {
+    $validator = createUserWithRole('Validator');
+    $layer = createLayer($validator->id);
+
+    assertGateAllows($validator, 'delete', $layer, false);
+});
+
+test('validators cannot delete other users layers', function () {
+    $validator = createUserWithRole('Validator');
+    $layer = createLayer(User::factory()->create()->id);
+
+    assertGateAllows($validator, 'delete', $layer, false);
+});
+
+test('validators cannot create layers', function () {
+    $validator = createUserWithRole('Validator');
+
+    assertGateAllows($validator, 'create', Layer::class, false);
+});
+
+test('validators can view any layer', function () {
+    $validator = createUserWithRole('Validator');
+    $layer = createLayer();
+
+    assertGateAllows($validator, 'view', $layer, true);
+});
+
+test('validators can view any layers list', function () {
+    $validator = createUserWithRole('Validator');
+
+    assertGateAllows($validator, 'viewAny', Layer::class, true);
+});

--- a/tests/Feature/LayerPolicyTest.php
+++ b/tests/Feature/LayerPolicyTest.php
@@ -1,95 +1,210 @@
 <?php
 
+namespace Tests\Feature;
+
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Gate;
+use Tests\Feature\Helpers\LayerTestHelpers;
+use Tests\TestCase;
 use Wm\WmPackage\Models\App;
 use Wm\WmPackage\Models\Layer;
 use Wm\WmPackage\Services\RolesAndPermissionsService;
 
-require_once __DIR__.'/Helpers/LayerTestHelpers.php';
-
-uses(DatabaseTransactions::class);
-
-beforeEach(function () {
-    // Seed roles and permissions
-    RolesAndPermissionsService::seedDatabase();
-
-    // Create an App for layers (required by LayerFactory)
-    if (App::count() === 0) {
-        App::factory()->create();
-    }
-});
-
-function assertGateAllows(User $user, string $ability, Layer|string $layer, bool $expected): void
+class LayerPolicyTest extends TestCase
 {
-    expect(Gate::forUser($user)->allows($ability, $layer))->toBe($expected);
+    use DatabaseTransactions, LayerTestHelpers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Seed roles and permissions
+        RolesAndPermissionsService::seedDatabase();
+
+        // Create an App for layers (required by LayerFactory)
+        if (App::count() === 0) {
+            App::factory()->create();
+        }
+    }
+
+    // =========================================================================
+    // Administrator Tests
+    // =========================================================================
+
+    public function test_administrator_can_view_any_layer(): void
+    {
+        $administrator = $this->createUserWithRole('Administrator');
+        $layer = $this->createLayer();
+
+        $this->assertTrue(Gate::forUser($administrator)->allows('view', $layer));
+    }
+
+    public function test_administrator_can_view_any_layers_list(): void
+    {
+        $administrator = $this->createUserWithRole('Administrator');
+
+        $this->assertTrue(Gate::forUser($administrator)->allows('viewAny', Layer::class));
+    }
+
+    public function test_administrator_can_create_layers(): void
+    {
+        $administrator = $this->createUserWithRole('Administrator');
+
+        $this->assertTrue(Gate::forUser($administrator)->allows('create', Layer::class));
+    }
+
+    public function test_administrator_can_update_any_layer(): void
+    {
+        $administrator = $this->createUserWithRole('Administrator');
+        $otherUser = User::factory()->create();
+        $layer = $this->createLayer($otherUser->id);
+
+        $this->assertTrue(Gate::forUser($administrator)->allows('update', $layer));
+    }
+
+    public function test_administrator_can_delete_any_layer(): void
+    {
+        $administrator = $this->createUserWithRole('Administrator');
+        $otherUser = User::factory()->create();
+        $layer = $this->createLayer($otherUser->id);
+
+        $this->assertTrue(Gate::forUser($administrator)->allows('delete', $layer));
+    }
+
+    public function test_administrator_can_update_own_layer(): void
+    {
+        $administrator = $this->createUserWithRole('Administrator');
+        $layer = $this->createLayer($administrator->id);
+
+        $this->assertTrue(Gate::forUser($administrator)->allows('update', $layer));
+    }
+
+    public function test_administrator_can_delete_own_layer(): void
+    {
+        $administrator = $this->createUserWithRole('Administrator');
+        $layer = $this->createLayer($administrator->id);
+
+        $this->assertTrue(Gate::forUser($administrator)->allows('delete', $layer));
+    }
+
+    // =========================================================================
+    // Validator Tests
+    // =========================================================================
+
+    public function test_validator_can_view_any_layer(): void
+    {
+        $validator = $this->createUserWithRole('Validator');
+        $layer = $this->createLayer();
+
+        $this->assertTrue(Gate::forUser($validator)->allows('view', $layer));
+    }
+
+    public function test_validator_can_view_any_layers_list(): void
+    {
+        $validator = $this->createUserWithRole('Validator');
+
+        $this->assertTrue(Gate::forUser($validator)->allows('viewAny', Layer::class));
+    }
+
+    public function test_validator_cannot_create_layers(): void
+    {
+        $validator = $this->createUserWithRole('Validator');
+
+        $this->assertFalse(Gate::forUser($validator)->allows('create', Layer::class));
+    }
+
+    public function test_validator_cannot_update_own_layer(): void
+    {
+        $validator = $this->createUserWithRole('Validator');
+        $layer = $this->createLayer($validator->id);
+
+        $this->assertFalse(Gate::forUser($validator)->allows('update', $layer));
+    }
+
+    public function test_validator_cannot_update_other_users_layer(): void
+    {
+        $validator = $this->createUserWithRole('Validator');
+        $otherUser = User::factory()->create();
+        $layer = $this->createLayer($otherUser->id);
+
+        $this->assertFalse(Gate::forUser($validator)->allows('update', $layer));
+    }
+
+    public function test_validator_cannot_delete_own_layer(): void
+    {
+        $validator = $this->createUserWithRole('Validator');
+        $layer = $this->createLayer($validator->id);
+
+        $this->assertFalse(Gate::forUser($validator)->allows('delete', $layer));
+    }
+
+    public function test_validator_cannot_delete_other_users_layer(): void
+    {
+        $validator = $this->createUserWithRole('Validator');
+        $otherUser = User::factory()->create();
+        $layer = $this->createLayer($otherUser->id);
+
+        $this->assertFalse(Gate::forUser($validator)->allows('delete', $layer));
+    }
+
+    // =========================================================================
+    // User Without Role Tests
+    // =========================================================================
+
+    public function test_user_without_role_can_view_any_layer(): void
+    {
+        $user = $this->createUserWithoutRole();
+        $layer = $this->createLayer();
+
+        $this->assertTrue(Gate::forUser($user)->allows('view', $layer));
+    }
+
+    public function test_user_without_role_can_view_any_layers_list(): void
+    {
+        $user = $this->createUserWithoutRole();
+
+        $this->assertTrue(Gate::forUser($user)->allows('viewAny', Layer::class));
+    }
+
+    public function test_user_without_role_cannot_create_layers(): void
+    {
+        $user = $this->createUserWithoutRole();
+
+        $this->assertFalse(Gate::forUser($user)->allows('create', Layer::class));
+    }
+
+    public function test_user_without_role_can_update_own_layer(): void
+    {
+        $user = $this->createUserWithoutRole();
+        $layer = $this->createLayer($user->id);
+
+        $this->assertTrue(Gate::forUser($user)->allows('update', $layer));
+    }
+
+    public function test_user_without_role_cannot_update_other_users_layer(): void
+    {
+        $user = $this->createUserWithoutRole();
+        $otherUser = User::factory()->create();
+        $layer = $this->createLayer($otherUser->id);
+
+        $this->assertFalse(Gate::forUser($user)->allows('update', $layer));
+    }
+
+    public function test_user_without_role_can_delete_own_layer(): void
+    {
+        $user = $this->createUserWithoutRole();
+        $layer = $this->createLayer($user->id);
+
+        $this->assertTrue(Gate::forUser($user)->allows('delete', $layer));
+    }
+
+    public function test_user_without_role_cannot_delete_other_users_layer(): void
+    {
+        $user = $this->createUserWithoutRole();
+        $otherUser = User::factory()->create();
+        $layer = $this->createLayer($otherUser->id);
+
+        $this->assertFalse(Gate::forUser($user)->allows('delete', $layer));
+    }
 }
-
-// Policy tests
-test('administrators can update any layer', function () {
-    $administrator = createUserWithRole('Administrator');
-    $layer = createLayer(User::factory()->create()->id);
-
-    assertGateAllows($administrator, 'update', $layer, true);
-});
-
-test('administrators can delete any layer', function () {
-    $administrator = createUserWithRole('Administrator');
-    $layer = createLayer(User::factory()->create()->id);
-
-    assertGateAllows($administrator, 'delete', $layer, true);
-});
-
-test('administrators can create layers', function () {
-    $administrator = createUserWithRole('Administrator');
-
-    assertGateAllows($administrator, 'create', Layer::class, true);
-});
-
-test('validators cannot update their own layers', function () {
-    $validator = createUserWithRole('Validator');
-    $layer = createLayer($validator->id);
-
-    assertGateAllows($validator, 'update', $layer, false);
-});
-
-test('validators cannot update other users layers', function () {
-    $validator = createUserWithRole('Validator');
-    $layer = createLayer(User::factory()->create()->id);
-
-    assertGateAllows($validator, 'update', $layer, false);
-});
-
-test('validators cannot delete their own layers', function () {
-    $validator = createUserWithRole('Validator');
-    $layer = createLayer($validator->id);
-
-    assertGateAllows($validator, 'delete', $layer, false);
-});
-
-test('validators cannot delete other users layers', function () {
-    $validator = createUserWithRole('Validator');
-    $layer = createLayer(User::factory()->create()->id);
-
-    assertGateAllows($validator, 'delete', $layer, false);
-});
-
-test('validators cannot create layers', function () {
-    $validator = createUserWithRole('Validator');
-
-    assertGateAllows($validator, 'create', Layer::class, false);
-});
-
-test('validators can view any layer', function () {
-    $validator = createUserWithRole('Validator');
-    $layer = createLayer();
-
-    assertGateAllows($validator, 'view', $layer, true);
-});
-
-test('validators can view any layers list', function () {
-    $validator = createUserWithRole('Validator');
-
-    assertGateAllows($validator, 'viewAny', Layer::class, true);
-});


### PR DESCRIPTION
- Introduced `LayerTestHelpers.php` to encapsulate helper functions for creating users and layers in tests.
  - `createUserWithRole`: Creates a user and assigns a role, with special handling for 'regular' users.
  - `createLayer`: Creates a layer with an optional user ID.

- Implemented `LayerPolicyTest.php` to verify various user roles' abilities to interact with layers.
  - Tests cover administrator and validator roles.
  - Ensured administrators can create, update, and delete any layer.
  - Validated that validators cannot create, update, or delete layers but can view them.
