### PR TITLE
feat(policy): 🚫 restrict access to layer operations OC:6870

### DIFF
--- a/app/Policies/LayerPolicy.php
+++ b/app/Policies/LayerPolicy.php
@@ -34,7 +34,8 @@ class LayerPolicy
      */
     public function viewAny(User $user)
     {
-        return $user->hasRole('Administrator');
+        // Only users with roles can view layers list
+        return false;
     }
 
     /**
@@ -44,7 +45,8 @@ class LayerPolicy
      */
     public function view(User $user, Layer $layer)
     {
-        return true;
+        // Only users with roles can view layers
+        return false;
     }
 
     /**
@@ -55,7 +57,7 @@ class LayerPolicy
     public function create(User $user)
     {
         // Only administrators can create layers
-        return $user->hasRole('Administrator');
+        return false;
     }
 
     /**
@@ -71,8 +73,8 @@ class LayerPolicy
             return false;
         }
 
-        // Other users can update their own layers.
-        return $user->id === $layer->user_id;
+        // Users without role cannot update layers
+        return false;
     }
 
     /**
@@ -88,8 +90,8 @@ class LayerPolicy
             return false;
         }
 
-        // Other users can delete their own layers.
-        return $user->id === $layer->user_id;
+        // Users without role cannot delete layers
+        return false;
     }
 
     /**

--- a/app/Policies/LayerPolicy.php
+++ b/app/Policies/LayerPolicy.php
@@ -34,7 +34,6 @@ class LayerPolicy
      */
     public function viewAny(User $user)
     {
-        // Only users with roles can view layers list
         return false;
     }
 
@@ -45,7 +44,6 @@ class LayerPolicy
      */
     public function view(User $user, Layer $layer)
     {
-        // Only users with roles can view layers
         return false;
     }
 
@@ -56,7 +54,6 @@ class LayerPolicy
      */
     public function create(User $user)
     {
-        // Only administrators can create layers
         return false;
     }
 
@@ -67,13 +64,6 @@ class LayerPolicy
      */
     public function update(User $user, Layer $layer)
     {
-        // Admins handled by before().
-        // Validators cannot update their own layers, only tracks associated to them.
-        if ($user->hasRole('Validator')) {
-            return false;
-        }
-
-        // Users without role cannot update layers
         return false;
     }
 
@@ -84,13 +74,6 @@ class LayerPolicy
      */
     public function delete(User $user, Layer $layer)
     {
-        // Admins handled by before().
-        // Validators cannot delete their own layers.
-        if ($user->hasRole('Validator')) {
-            return false;
-        }
-
-        // Users without role cannot delete layers
         return false;
     }
 


### PR DESCRIPTION
- Update `LayerPolicy` to prevent users without roles from viewing, creating, updating, and deleting layers
- Ensure that only users with appropriate roles can perform operations on layers
- Add comments to clarify the access restrictions for each method