### PR TITLE
Aggiunto EcPoi in sidebar (Oc 7111)

### DIFF
--- a/app/Models/EcPoi.php
+++ b/app/Models/EcPoi.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use Wm\WmPackage\Models\Ecpoi as WmEcPoi;
+use Wm\WmPackage\Models\EcPoi as WmEcPoi;
 
 class EcPoi extends WmEcPoi
 {

--- a/app/Models/EcPoi.php
+++ b/app/Models/EcPoi.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Wm\WmPackage\Models\Ecpoi as WmEcPoi;
+
+class EcPoi extends WmEcPoi
+{
+
+}

--- a/app/Models/EcPoi.php
+++ b/app/Models/EcPoi.php
@@ -4,7 +4,4 @@ namespace App\Models;
 
 use Wm\WmPackage\Models\EcPoi as WmEcPoi;
 
-class EcPoi extends WmEcPoi
-{
-
-}
+class EcPoi extends WmEcPoi {}

--- a/app/Models/TaxonomyPoiType.php
+++ b/app/Models/TaxonomyPoiType.php
@@ -4,7 +4,4 @@ namespace App\Models;
 
 use Wm\WmPackage\Models\TaxonomyPoiType as WmTaxonomyPoiType;
 
-class TaxonomyPoiType extends WmTaxonomyPoiType
-{
-
-}
+class TaxonomyPoiType extends WmTaxonomyPoiType {}

--- a/app/Models/TaxonomyPoiType.php
+++ b/app/Models/TaxonomyPoiType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Wm\WmPackage\Models\TaxonomyPoiType as WmTaxonomyPoiType;
+
+class TaxonomyPoiType extends WmTaxonomyPoiType
+{
+
+}

--- a/app/Nova/EcPoi.php
+++ b/app/Nova/EcPoi.php
@@ -2,10 +2,10 @@
 
 namespace App\Nova;
 
-use Wm\WmPackage\Nova\EcPoi as WmNovaEcPoi;
 use App\Models\EcPoi as EcPoiModel;
+use Wm\WmPackage\Nova\EcPoi as WmNovaEcPoi;
 
-class EcPoi extends WmNovaEcPoi 
+class EcPoi extends WmNovaEcPoi
 {
     public static $model = EcPoiModel::class;
 

--- a/app/Nova/EcPoi.php
+++ b/app/Nova/EcPoi.php
@@ -3,8 +3,11 @@
 namespace App\Nova;
 
 use Wm\WmPackage\Nova\EcPoi as WmNovaEcPoi;
+use App\Models\EcPoi as EcPoiModel;
 
-class EcPoi extends WmNovaEcPoi {
+class EcPoi extends WmNovaEcPoi 
+{
+    public static $model = EcPoiModel::class;
 
     public static function label(): string
     {

--- a/app/Nova/EcPoi.php
+++ b/app/Nova/EcPoi.php
@@ -4,4 +4,10 @@ namespace App\Nova;
 
 use Wm\WmPackage\Nova\EcPoi as WmNovaEcPoi;
 
-class EcPoi extends WmNovaEcPoi {}
+class EcPoi extends WmNovaEcPoi {
+
+    public static function label(): string
+    {
+        return __('Pois');
+    }
+}

--- a/app/Nova/TaxonomyPoiType.php
+++ b/app/Nova/TaxonomyPoiType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Nova;
+
+use Wm\WmPackage\Nova\TaxonomyPoiType as WmTaxonomyPoiType;
+
+class TaxonomyPoiType extends WmTaxonomyPoiType {
+
+    public static $model = \App\Models\TaxonomyPoiType::class;
+
+}

--- a/app/Nova/TaxonomyPoiType.php
+++ b/app/Nova/TaxonomyPoiType.php
@@ -4,8 +4,7 @@ namespace App\Nova;
 
 use Wm\WmPackage\Nova\TaxonomyPoiType as WmTaxonomyPoiType;
 
-class TaxonomyPoiType extends WmTaxonomyPoiType {
-
+class TaxonomyPoiType extends WmTaxonomyPoiType
+{
     public static $model = \App\Models\TaxonomyPoiType::class;
-
 }

--- a/app/Nova/UgcPoi.php
+++ b/app/Nova/UgcPoi.php
@@ -8,4 +8,9 @@ use Wm\WmPackage\Nova\UgcPoi as WmNovaUgcPoi;
 class UgcPoi extends WmNovaUgcPoi
 {
     use HidesAppFromIndexTrait;
+
+    public static function label(): string
+    {
+        return __('Pois');
+    }
 }

--- a/app/Nova/UgcTrack.php
+++ b/app/Nova/UgcTrack.php
@@ -8,4 +8,9 @@ use Wm\WmPackage\Nova\UgcTrack as WmNovaUgcTrack;
 class UgcTrack extends WmNovaUgcTrack
 {
     use HidesAppFromIndexTrait;
+
+    public static function label(): string
+    {
+        return __('Tracks');
+    }
 }

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\LayerFeatureController;
 use App\Models\User;
 use App\Nova\App;
 use App\Nova\Dashboards\Main;
+use App\Nova\EcPoi;
 use App\Nova\EcTrack;
 use App\Nova\Layer;
 use App\Nova\Media;
@@ -22,7 +23,6 @@ use Laravel\Nova\Menu\MenuItem;
 use Laravel\Nova\Menu\MenuSection;
 use Laravel\Nova\Nova;
 use Laravel\Nova\NovaApplicationServiceProvider;
-use App\Nova\EcPoi;
 
 class NovaServiceProvider extends NovaApplicationServiceProvider
 {
@@ -68,10 +68,10 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                     MenuItem::resource(Layer::class),
                 ])->icon('document'),
 
-                 MenuSection::make('Taxonomies', [
-                     MenuItem::resource(TaxonomyPoiType::class),
-//                     MenuItem::resource(TaxonomyActivity::class),
-                 ])->icon('document'),
+                MenuSection::make('Taxonomies', [
+                    MenuItem::resource(TaxonomyPoiType::class),
+                    //                     MenuItem::resource(TaxonomyActivity::class),
+                ])->icon('document'),
 
             ];
         });

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -9,6 +9,7 @@ use App\Nova\Dashboards\Main;
 use App\Nova\EcTrack;
 use App\Nova\Layer;
 use App\Nova\Media;
+use App\Nova\TaxonomyPoiType;
 use App\Nova\UgcPoi;
 use App\Nova\UgcTrack;
 use App\Nova\User as NovaUser;
@@ -67,9 +68,10 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                     MenuItem::resource(Layer::class),
                 ])->icon('document'),
 
-                // MenuSection::make('Taxonomies', [
-                //     MenuItem::resource(TaxonomyActivity::class),
-                // ])->icon('document'),
+                 MenuSection::make('Taxonomies', [
+                     MenuItem::resource(TaxonomyPoiType::class),
+//                     MenuItem::resource(TaxonomyActivity::class),
+                 ])->icon('document'),
 
             ];
         });

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -21,7 +21,7 @@ use Laravel\Nova\Menu\MenuItem;
 use Laravel\Nova\Menu\MenuSection;
 use Laravel\Nova\Nova;
 use Laravel\Nova\NovaApplicationServiceProvider;
-use Wm\WmPackage\Nova\EcPoi;
+use App\Nova\EcPoi;
 
 class NovaServiceProvider extends NovaApplicationServiceProvider
 {
@@ -62,7 +62,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                 ])->icon('document'),
 
                 MenuSection::make('EC', [
-                    // MenuItem::resource(EcPoi::class),
+                    MenuItem::resource(EcPoi::class),
                     MenuItem::resource(EcTrack::class),
                     MenuItem::resource(Layer::class),
                 ])->icon('document'),


### PR DESCRIPTION
Aggiunti in sidebar gli EcPoi e i TaxonomyPoiType

Restano da vedere:
- forse la traduzione del menu item
- il perché non pesca le icone alla creazione del tipo POI