### PR TITLE
feat(migrations): add global column to ec_pois table oc:7158

### DIFF
--- a/database/migrations/2026_02_16_131347_zz_2026_02_16_120001_add_global_to_ec_pois.php
+++ b/database/migrations/2026_02_16_131347_zz_2026_02_16_120001_add_global_to_ec_pois.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ec_pois', function (Blueprint $table) {
+            $table->boolean('global')->default(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ec_pois', function (Blueprint $table) {
+            $table->dropColumn('global');
+        });
+    }
+};


### PR DESCRIPTION
- Introduced a new migration to add a boolean 'global' column to the 'ec_pois' table with a default value of true.
- Implemented the down method to drop the 'global' column if the migration is rolled back.
