### PR TITLE
fix(migration): 🐛 rename migration file to avoid conflict OC:7480

### DIFF
--- a/app/Http/Controllers/LayerFeatureController.php
+++ b/app/Http/Controllers/LayerFeatureController.php
@@ -4,9 +4,11 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Models\User;
 use Wm\WmPackage\Nova\Fields\LayerFeatures\Http\Controllers\LayerFeatureController as WmLayerFeatureController;
 
 class LayerFeatureController extends WmLayerFeatureController
@@ -39,7 +41,7 @@ class LayerFeatureController extends WmLayerFeatureController
             }
 
             // Ottieni l'utente loggato
-            /** @var \Wm\WmPackage\Models\User|null $user */
+            /** @var User|null $user */
             $user = Auth::user();
 
             // Funzione helper per caricare le features associate
@@ -100,7 +102,7 @@ class LayerFeatureController extends WmLayerFeatureController
                 $paginatedFeatures = $allFeatures->slice($offset, $perPage);
 
                 // Crea un oggetto paginazione manuale
-                $features = new \Illuminate\Pagination\LengthAwarePaginator(
+                $features = new LengthAwarePaginator(
                     $paginatedFeatures,
                     $total,
                     $perPage,

--- a/app/Models/EcTrack.php
+++ b/app/Models/EcTrack.php
@@ -24,7 +24,7 @@ class EcTrack extends WmEcTrack
             }
 
             // Se l'utente è un Validator, imposta automaticamente se stesso
-            /** @var \App\Models\User|null $currentUser */
+            /** @var User|null $currentUser */
             $currentUser = Auth::user();
             if (empty($ecTrack->user_id) && $currentUser) {
                 if ($currentUser->hasRole('Validator')) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Nova\Auth\Impersonatable;
@@ -9,7 +10,7 @@ use Wm\WmPackage\Models\User as WmUser;
 
 class User extends WmUser
 {
-    /** @use HasFactory<\Database\Factories\UserFactory> */
+    /** @use HasFactory<UserFactory> */
     use HasFactory, Impersonatable, Notifiable;
 
     /**

--- a/app/Nova/Dashboards/Main.php
+++ b/app/Nova/Dashboards/Main.php
@@ -2,6 +2,7 @@
 
 namespace App\Nova\Dashboards;
 
+use Laravel\Nova\Card;
 use Laravel\Nova\Cards\Help;
 use Laravel\Nova\Dashboards\Main as Dashboard;
 
@@ -10,7 +11,7 @@ class Main extends Dashboard
     /**
      * Get the cards for the dashboard.
      *
-     * @return array<int, \Laravel\Nova\Card>
+     * @return array<int, Card>
      */
     public function cards(): array
     {

--- a/app/Nova/Layer.php
+++ b/app/Nova/Layer.php
@@ -2,6 +2,7 @@
 
 namespace App\Nova;
 
+use App\Models\User;
 use App\Nova\Traits\FiltersUsersByRoleTrait;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Nova\Fields\BelongsTo;
@@ -21,7 +22,7 @@ class Layer extends WmNovaLayer
      */
     public static function indexQuery(NovaRequest $request, $query)
     {
-        /** @var \App\Models\User|null $user */
+        /** @var User|null $user */
         $user = Auth::user();
 
         if ($user && ! $user->hasRole('Administrator')) {

--- a/app/Policies/LayerPolicy.php
+++ b/app/Policies/LayerPolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
 use Wm\WmPackage\Models\Layer;
 
 class LayerPolicy
@@ -30,7 +31,7 @@ class LayerPolicy
     /**
      * Determine whether the user can view any models.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function viewAny(User $user)
     {
@@ -40,7 +41,7 @@ class LayerPolicy
     /**
      * Determine whether the user can view the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function view(User $user, Layer $layer)
     {
@@ -50,7 +51,7 @@ class LayerPolicy
     /**
      * Determine whether the user can create models.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function create(User $user)
     {
@@ -60,7 +61,7 @@ class LayerPolicy
     /**
      * Determine whether the user can update the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function update(User $user, Layer $layer)
     {
@@ -70,7 +71,7 @@ class LayerPolicy
     /**
      * Determine whether the user can delete the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function delete(User $user, Layer $layer)
     {
@@ -80,7 +81,7 @@ class LayerPolicy
     /**
      * Determine whether the user can restore the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function restore(User $user, Layer $layer)
     {
@@ -90,7 +91,7 @@ class LayerPolicy
     /**
      * Determine whether the user can permanently delete the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function forceDelete(User $user, Layer $layer)
     {

--- a/app/Policies/TaxonomyPoiTypePolicy.php
+++ b/app/Policies/TaxonomyPoiTypePolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Models\TaxonomyPoiType;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
 
 class TaxonomyPoiTypePolicy
 {
@@ -26,7 +27,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can view any models.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function viewAny(User $user)
     {
@@ -37,7 +38,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can view the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function view(User $user, TaxonomyPoiType|\Laravel\Nova\Resource $taxonomyPoiType): bool
     {
@@ -47,7 +48,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can create models.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function create(User $user)
     {
@@ -58,7 +59,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can update the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function update(User $user, TaxonomyPoiType|\Laravel\Nova\Resource $taxonomyPoiType): bool
     {
@@ -68,7 +69,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can delete the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function delete(User $user, TaxonomyPoiType|\Laravel\Nova\Resource $taxonomyPoiType)
     {
@@ -78,7 +79,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can restore the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function restore(User $user, TaxonomyPoiType|\Laravel\Nova\Resource $taxonomyPoiType)
     {
@@ -88,7 +89,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can permanently delete the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function forceDelete(User $user, TaxonomyPoiType|\Laravel\Nova\Resource $taxonomyPoiType)
     {

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -19,10 +19,12 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
+use Laravel\Nova\Dashboard;
 use Laravel\Nova\Menu\MenuItem;
 use Laravel\Nova\Menu\MenuSection;
 use Laravel\Nova\Nova;
 use Laravel\Nova\NovaApplicationServiceProvider;
+use Laravel\Nova\Tool;
 
 class NovaServiceProvider extends NovaApplicationServiceProvider
 {
@@ -125,19 +127,19 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
     /**
      * Get the dashboards that should be listed in the Nova sidebar.
      *
-     * @return array<int, \Laravel\Nova\Dashboard>
+     * @return array<int, Dashboard>
      */
     protected function dashboards(): array
     {
         return [
-            new \App\Nova\Dashboards\Main,
+            new Main,
         ];
     }
 
     /**
      * Get the tools that should be listed in the Nova sidebar.
      *
-     * @return array<int, \Laravel\Nova\Tool>
+     * @return array<int, Tool>
      */
     public function tools(): array
     {

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,8 +1,13 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+use App\Providers\HorizonServiceProvider;
+use App\Providers\NovaServiceProvider;
+use App\Providers\TelescopeServiceProvider;
+
 return [
-    App\Providers\AppServiceProvider::class,
-    App\Providers\HorizonServiceProvider::class,
-    App\Providers\NovaServiceProvider::class,
-    App\Providers\TelescopeServiceProvider::class,
+    AppServiceProvider::class,
+    HorizonServiceProvider::class,
+    NovaServiceProvider::class,
+    TelescopeServiceProvider::class,
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\User;
+
 return [
 
     /*
@@ -66,7 +68,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            'model' => env('AUTH_MODEL', User::class),
         ],
 
         // 'users' => [

--- a/config/jwt.php
+++ b/config/jwt.php
@@ -1,5 +1,9 @@
 <?php
 
+use Tymon\JWTAuth\Providers\Auth\Illuminate;
+use Tymon\JWTAuth\Providers\JWT\Lcobucci;
+use Tymon\JWTAuth\Providers\JWT\Provider;
+
 /*
  * This file is part of jwt-auth.
  *
@@ -131,7 +135,7 @@ return [
     |
     */
 
-    'algo' => env('JWT_ALGO', Tymon\JWTAuth\Providers\JWT\Provider::ALGO_HS256),
+    'algo' => env('JWT_ALGO', Provider::ALGO_HS256),
 
     /*
     |--------------------------------------------------------------------------
@@ -272,7 +276,7 @@ return [
         |
         */
 
-        'jwt' => Tymon\JWTAuth\Providers\JWT\Lcobucci::class,
+        'jwt' => Lcobucci::class,
 
         /*
         |--------------------------------------------------------------------------
@@ -283,7 +287,7 @@ return [
         |
         */
 
-        'auth' => Tymon\JWTAuth\Providers\Auth\Illuminate::class,
+        'auth' => Illuminate::class,
 
         /*
         |--------------------------------------------------------------------------

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,12 +2,13 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<User>
  */
 class UserFactory extends Factory
 {

--- a/database/migrations/2026_03_30_120000_zz_2026_03_30_120000_add_my_routes_image_and_my_downloads_image_to_apps_table.php
+++ b/database/migrations/2026_03_30_120000_zz_2026_03_30_120000_add_my_routes_image_and_my_downloads_image_to_apps_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('apps', function (Blueprint $table) {
+            $table->string('my_routes_image')->nullable()->after('icon_small');
+            $table->string('my_downloads_image')->nullable()->after('my_routes_image');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('apps', function (Blueprint $table) {
+            $table->dropColumn(['my_routes_image', 'my_downloads_image']);
+        });
+    }
+};

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Tests\TestCase;
+
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -11,7 +13,7 @@
 |
 */
 
-pest()->extend(Tests\TestCase::class)
+pest()->extend(TestCase::class)
  // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Feature');
 


### PR DESCRIPTION
- Adjusted the filename to ensure it is unique and does not conflict with existing migration files.
- Added a prefix 'zz_' to the migration filename for better sorting and organization.
