### PR TITLE
feat(nova): add home tab layer sorting feature OC:7644

### DIFF
--- a/app/Nova/App.php
+++ b/app/Nova/App.php
@@ -31,11 +31,11 @@ class App extends NovaApp
     protected function configHomeSortTriggerMarkup(): string
     {
         $title = e(__('Sort Home Layers'));
-        $description = e(__('Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking.'));
+        $description = e(__('Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking. Click Update to save the new order.'));
         $buttonLabel = e(__('Sort Layers A-Z'));
         $errorMessage = e(__('Unable to find the home content to sort.'));
         $infoMessage = e(__('Layers are already sorted within each group.'));
-        $successMessage = e(__('Layers sorted alphabetically within each group.'));
+        $successMessage = e(__('Layers sorted alphabetically within each group. Click Update to save the new order.'));
 
         return <<<HTML
             <div class="wm-config-home-sorter rounded-lg border border-gray-200 dark:border-gray-700 p-4">

--- a/app/Nova/App.php
+++ b/app/Nova/App.php
@@ -2,6 +2,63 @@
 
 namespace App\Nova;
 
+use Laravel\Nova\Fields\Heading;
+use Whitecube\NovaFlexibleContent\Flexible;
 use Wm\WmPackage\Nova\App as NovaApp;
 
-class App extends NovaApp {}
+class App extends NovaApp
+{
+    protected function home_tab(): array
+    {
+        $fields = parent::home_tab();
+        $sortTrigger = Heading::make($this->configHomeSortTriggerMarkup())
+            ->asHtml()
+            ->onlyOnForms();
+
+        foreach ($fields as $index => $field) {
+            if ($field instanceof Flexible && $field->attribute === 'config_home') {
+                array_splice($fields, $index, 0, [$sortTrigger]);
+
+                return $fields;
+            }
+        }
+
+        $fields[] = $sortTrigger;
+
+        return $fields;
+    }
+
+    protected function configHomeSortTriggerMarkup(): string
+    {
+        $title = e(__('Sort Home Layers'));
+        $description = e(__('Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking.'));
+        $buttonLabel = e(__('Sort Layers A-Z'));
+        $errorMessage = e(__('Unable to find the home content to sort.'));
+        $infoMessage = e(__('Layers are already sorted within each group.'));
+        $successMessage = e(__('Layers sorted alphabetically within each group.'));
+
+        return <<<HTML
+            <div class="wm-config-home-sorter rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+                <div>
+                    <h3 style="font-size: 1rem; font-weight: 700; margin: 0;">{$title}</h3>
+                    <p style="margin: 0.35rem 0 0; color: rgb(107 114 128);">
+                        {$description}
+                    </p>
+                </div>
+                <div style="margin-top: 0.85rem;">
+                    <button
+                        type="button"
+                        data-config-home-sort-trigger="true"
+                        data-config-home-sort-attribute="config_home"
+                        data-config-home-sort-error="{$errorMessage}"
+                        data-config-home-sort-info="{$infoMessage}"
+                        data-config-home-sort-success="{$successMessage}"
+                        class="cursor-pointer rounded-md bg-primary-500 px-4 py-2 font-semibold text-white shadow hover:bg-primary-400 focus:outline-none focus:ring"
+                    >
+                        {$buttonLabel}
+                    </button>
+                </div>
+            </div>
+        HTML;
+    }
+}

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
+use Laravel\Nova\Events\ServingNova;
 use Laravel\Nova\Menu\MenuItem;
 use Laravel\Nova\Menu\MenuSection;
 use Laravel\Nova\Nova;
@@ -34,6 +35,10 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
     public function boot(): void
     {
         parent::boot();
+
+        Nova::serving(function (ServingNova $event) {
+            Nova::script('config-home-sorter', resource_path('js/nova/config-home-sorter.js'));
+        });
 
         // Questa route sovrascrive quella del wm-package permettendo
         // di filtrare le tracce per utente loggato senza modificare il package.

--- a/docs/features/7644-ordinamento-alfabetico-automatico-dei-layer-nel-backend/notes.md
+++ b/docs/features/7644-ordinamento-alfabetico-automatico-dei-layer-nel-backend/notes.md
@@ -1,0 +1,17 @@
+> Ticket: oc:7644
+
+# Notes — Ordinamento alfabetico automatico dei layer nel backend
+
+## Deviazioni dal piano
+Nessuna deviazione rilevante.
+
+## Bug trovati
+Nessuno.
+
+## Decisioni
+- Aggiornato anche `$successMessage` oltre a `$description`: il messaggio di successo è il
+  momento di massima attenzione dell'utente dopo il click, quindi il reminder "Click Update"
+  è più efficace lì che solo nella descrizione statica.
+
+## Follow-up
+Nessuno.

--- a/docs/features/7644-ordinamento-alfabetico-automatico-dei-layer-nel-backend/overview.md
+++ b/docs/features/7644-ordinamento-alfabetico-automatico-dei-layer-nel-backend/overview.md
@@ -1,0 +1,35 @@
+> Ticket: oc:7644
+
+# Ordinamento alfabetico automatico dei layer nel backend
+
+## Cosa cambia
+Il testo helper del pulsante "Sort Layers A-Z" e il messaggio di successo vengono aggiornati
+per comunicare esplicitamente che dopo aver ordinato i layer bisogna cliccare **Update**
+("Aggiorna" in italiano) per rendere definitivo il nuovo ordinamento.
+
+## Perché
+In fase di testing è emerso che gli utenti non capiscono che il click sul pulsante di
+ordinamento non persiste automaticamente le modifiche: Nova richiede un salvataggio esplicito
+della risorsa. Aggiungere il reminder nel punto di massima attenzione (descrizione + messaggio
+di successo) elimina questa ambiguità.
+
+## Requisiti
+- [ ] `$description` aggiornato con "Click **Update** to save the new order." (EN) e
+      "Clicca **Aggiorna** per rendere definitivo il nuovo ordinamento." (IT)
+- [ ] `$successMessage` aggiornato con lo stesso reminder
+- [ ] `resources/lang/en.json` aggiornato con le nuove chiavi
+- [ ] `resources/lang/it.json` aggiornato con le nuove chiavi
+
+## Rischi
+- Nessun rischio architetturale. Il testo è HTML-escaped tramite `e(__(...))`.
+- Fallback Nova: se una chiave manca nel file di lingua, viene restituita la stringa inglese.
+
+## Out of scope
+- Modifiche alla logica di ordinamento
+- Modifiche ad altri messaggi (error, info)
+- Aggiornamenti al submodule wm-package
+
+## Moduli toccati
+- `app/Nova/App.php` — metodo `configHomeSortTriggerMarkup()`
+- `resources/lang/en.json` — chiavi description e successMessage
+- `resources/lang/it.json` — chiavi description e successMessage

--- a/docs/features/7644-ordinamento-alfabetico-automatico-dei-layer-nel-backend/plan.md
+++ b/docs/features/7644-ordinamento-alfabetico-automatico-dei-layer-nel-backend/plan.md
@@ -1,0 +1,35 @@
+> Ticket: oc:7644
+
+# Plan — Aggiornamento helper testo pulsante ordinamento layer
+
+## Step 1 — Aggiorna `app/Nova/App.php`
+
+Modifica `configHomeSortTriggerMarkup()`:
+
+**`$description`** — nuova stringa:
+```
+Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking. Click Update to save the new order.
+```
+
+**`$successMessage`** — nuova stringa:
+```
+Layers sorted alphabetically within each group. Click Update to save the new order.
+```
+
+## Step 2 — Aggiorna `resources/lang/en.json`
+
+Rimuovere le vecchie chiavi e aggiungere:
+- chiave description (nuova stringa EN → stessa stringa EN)
+- chiave successMessage (nuova stringa EN → stessa stringa EN)
+
+## Step 3 — Aggiorna `resources/lang/it.json`
+
+Rimuovere le vecchie chiavi e aggiungere:
+- chiave description → "Ordina alfabeticamente solo i box Layer consecutivi. I box di altro tipo restano fermi e puoi comunque riordinare tutto manualmente dopo il click. Clicca Aggiorna per rendere definitivo il nuovo ordinamento."
+- chiave successMessage → "Layer ordinati alfabeticamente per ogni gruppo. Clicca Aggiorna per rendere definitivo il nuovo ordinamento."
+
+## Step 4 — Commit
+
+```
+feat(oc:7644): update sort helper text to mention Update button
+```

--- a/resources/js/nova/config-home-sorter.js
+++ b/resources/js/nova/config-home-sorter.js
@@ -1,0 +1,253 @@
+(function () {
+    const REQUEST_EVENT = 'wm:config-home-sort-request';
+    const registry = new Map();
+
+    function isConfigHomeFlexible(vm) {
+        return Boolean(
+            vm &&
+                vm.currentField &&
+                vm.currentField.attribute === 'config_home' &&
+                Array.isArray(vm.order) &&
+                vm.groups &&
+                typeof vm.groups === 'object'
+        );
+    }
+
+    function getRegistryKey(vm) {
+        return [
+            vm.resourceName || 'resource',
+            vm.resourceId || 'create',
+            vm.currentField.attribute,
+        ].join(':');
+    }
+
+    function normalizeFieldAttribute(attribute, groupKey) {
+        if (typeof attribute !== 'string') {
+            return '';
+        }
+
+        const prefix = `${groupKey}__`;
+
+        return attribute.startsWith(prefix) ? attribute.slice(prefix.length) : attribute;
+    }
+
+    function findLayerField(group) {
+        if (!group || !Array.isArray(group.fields)) {
+            return null;
+        }
+
+        return (
+            group.fields.find((field) => normalizeFieldAttribute(field.attribute, group.key) === 'layer') ||
+            group.fields.find((field) => field.name === 'Layer') ||
+            null
+        );
+    }
+
+    function getOptionLabel(field, selectedValue) {
+        if (!field || !Array.isArray(field.options)) {
+            return '';
+        }
+
+        const selected = field.options.find((option) => String(option.value) === String(selectedValue));
+
+        return selected && typeof selected.label === 'string' ? selected.label : '';
+    }
+
+    function getLayerLabelFromDom(groupKey) {
+        const groupElement = document.getElementById(groupKey);
+
+        if (!groupElement) {
+            return '';
+        }
+
+        const selectors = [
+            '.multiselect__single',
+            '[role="combobox"]',
+            'input[type="search"]',
+            'input:not([type="hidden"])',
+        ];
+
+        for (const selector of selectors) {
+            const element = groupElement.querySelector(selector);
+
+            if (!element) {
+                continue;
+            }
+
+            const rawValue = 'value' in element ? element.value : element.textContent;
+            const label = normalizeLabel(rawValue);
+
+            if (label !== '') {
+                return label;
+            }
+        }
+
+        return '';
+    }
+
+    function normalizeLabel(value) {
+        if (typeof value !== 'string') {
+            return '';
+        }
+
+        return value.replace(/\s+/g, ' ').trim();
+    }
+
+    function getLayerSortLabel(vm, key) {
+        const group = vm.groups[key];
+
+        if (!group || group.name !== 'layer') {
+            return '';
+        }
+
+        const layerField = findLayerField(group);
+        const optionLabel = layerField ? getOptionLabel(layerField, layerField.value) : '';
+        const domLabel = getLayerLabelFromDom(group.key);
+
+        return normalizeLabel(optionLabel || domLabel || '');
+    }
+
+    function sortLayerSegments(vm) {
+        const nextOrder = [];
+        let hasChanges = false;
+        let segment = [];
+
+        const flushSegment = () => {
+            if (segment.length === 0) {
+                return;
+            }
+
+            const originalSegment = segment.slice();
+            const sortedSegment = segment
+                .map((key, index) => ({
+                    key,
+                    index,
+                    label: getLayerSortLabel(vm, key),
+                }))
+                .sort((left, right) => {
+                    const byLabel = left.label.localeCompare(right.label, 'it', {
+                        sensitivity: 'base',
+                        numeric: true,
+                    });
+
+                    return byLabel !== 0 ? byLabel : left.index - right.index;
+                })
+                .map((item) => item.key);
+
+            if (sortedSegment.some((key, index) => key !== originalSegment[index])) {
+                hasChanges = true;
+            }
+
+            nextOrder.push(...sortedSegment);
+            segment = [];
+        };
+
+        vm.order.forEach((key) => {
+            const group = vm.groups[key];
+
+            if (group && group.name === 'layer') {
+                segment.push(key);
+
+                return;
+            }
+
+            flushSegment();
+            nextOrder.push(key);
+        });
+
+        flushSegment();
+
+        return { hasChanges, nextOrder };
+    }
+
+    function notify(type, message) {
+        if (typeof Nova === 'undefined') {
+            return;
+        }
+
+        const callback = Nova[type];
+
+        if (typeof callback === 'function') {
+            callback(message);
+        }
+    }
+
+    function messageFor(event, key, fallback) {
+        return event && event.detail && typeof event.detail[key] === 'string' && event.detail[key] !== ''
+            ? event.detail[key]
+            : fallback;
+    }
+
+    function handleSortRequest(event) {
+        const targetAttribute =
+            event && event.detail && typeof event.detail.attribute === 'string'
+                ? event.detail.attribute
+                : 'config_home';
+        const sorters = Array.from(registry.values()).filter(
+            (vm) => vm.currentField && vm.currentField.attribute === targetAttribute
+        );
+        const vm = sorters[sorters.length - 1];
+        const errorMessage = messageFor(event, 'errorMessage', 'Unable to find the home content to sort.');
+        const infoMessage = messageFor(event, 'infoMessage', 'Layers are already sorted within each group.');
+        const successMessage = messageFor(event, 'successMessage', 'Layers sorted alphabetically within each group.');
+
+        if (!vm) {
+            notify('error', errorMessage);
+
+            return;
+        }
+
+        const { hasChanges, nextOrder } = sortLayerSegments(vm);
+
+        if (!hasChanges) {
+            notify('info', infoMessage);
+
+            return;
+        }
+
+        vm.order.splice(0, vm.order.length, ...nextOrder);
+        notify('success', successMessage);
+    }
+
+    document.addEventListener('click', (event) => {
+        if (!(event.target instanceof Element)) {
+            return;
+        }
+
+        const trigger = event.target.closest('[data-config-home-sort-trigger="true"]');
+
+        if (!trigger) {
+            return;
+        }
+
+        event.preventDefault();
+        window.dispatchEvent(
+            new CustomEvent(REQUEST_EVENT, {
+                detail: {
+                    attribute: trigger.getAttribute('data-config-home-sort-attribute') || 'config_home',
+                    errorMessage: trigger.getAttribute('data-config-home-sort-error') || '',
+                    infoMessage: trigger.getAttribute('data-config-home-sort-info') || '',
+                    successMessage: trigger.getAttribute('data-config-home-sort-success') || '',
+                },
+            })
+        );
+    });
+
+    window.addEventListener(REQUEST_EVENT, handleSortRequest);
+
+    Nova.booting((app) => {
+        app.mixin({
+            mounted() {
+                if (isConfigHomeFlexible(this)) {
+                    registry.set(getRegistryKey(this), this);
+                }
+            },
+
+            beforeUnmount() {
+                if (isConfigHomeFlexible(this)) {
+                    registry.delete(getRegistryKey(this));
+                }
+            },
+        });
+    });
+})();

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1,8 +1,8 @@
 {
     "Sort Home Layers": "Sort Home Layers",
-    "Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking.": "Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking.",
+    "Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking. Click Update to save the new order.": "Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking. Click Update to save the new order.",
     "Sort Layers A-Z": "Sort Layers A-Z",
     "Unable to find the home content to sort.": "Unable to find the home content to sort.",
     "Layers are already sorted within each group.": "Layers are already sorted within each group.",
-    "Layers sorted alphabetically within each group.": "Layers sorted alphabetically within each group."
+    "Layers sorted alphabetically within each group. Click Update to save the new order.": "Layers sorted alphabetically within each group. Click Update to save the new order."
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1,0 +1,8 @@
+{
+    "Sort Home Layers": "Sort Home Layers",
+    "Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking.": "Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking.",
+    "Sort Layers A-Z": "Sort Layers A-Z",
+    "Unable to find the home content to sort.": "Unable to find the home content to sort.",
+    "Layers are already sorted within each group.": "Layers are already sorted within each group.",
+    "Layers sorted alphabetically within each group.": "Layers sorted alphabetically within each group."
+}

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -1,0 +1,8 @@
+{
+    "Sort Home Layers": "Ordina i layer della home",
+    "Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking.": "Ordina alfabeticamente solo i box Layer consecutivi. I box di altro tipo restano fermi e puoi comunque riordinare tutto manualmente dopo il click.",
+    "Sort Layers A-Z": "Ordina layer A-Z",
+    "Unable to find the home content to sort.": "Impossibile trovare il contenuto home da ordinare.",
+    "Layers are already sorted within each group.": "I layer sono gia ordinati per ogni gruppo.",
+    "Layers sorted alphabetically within each group.": "Layer ordinati alfabeticamente per gruppo."
+}

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -1,8 +1,8 @@
 {
     "Sort Home Layers": "Ordina i layer della home",
-    "Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking.": "Ordina alfabeticamente solo i box Layer consecutivi. I box di altro tipo restano fermi e puoi comunque riordinare tutto manualmente dopo il click.",
+    "Sort consecutive Layer boxes alphabetically. Other box types stay in place and you can still reorder everything manually after clicking. Click Update to save the new order.": "Ordina alfabeticamente solo i box Layer consecutivi. I box di altro tipo restano fermi e puoi comunque riordinare tutto manualmente dopo il click. Clicca Aggiorna per rendere definitivo il nuovo ordinamento.",
     "Sort Layers A-Z": "Ordina layer A-Z",
     "Unable to find the home content to sort.": "Impossibile trovare il contenuto home da ordinare.",
     "Layers are already sorted within each group.": "I layer sono gia ordinati per ogni gruppo.",
-    "Layers sorted alphabetically within each group.": "Layer ordinati alfabeticamente per gruppo."
+    "Layers sorted alphabetically within each group. Click Update to save the new order.": "Layer ordinati alfabeticamente per ogni gruppo. Clicca Aggiorna per rendere definitivo il nuovo ordinamento."
 }

--- a/tests/Feature/AppHomeLayerSortButtonTest.php
+++ b/tests/Feature/AppHomeLayerSortButtonTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Nova\App as NovaAppResource;
+use Illuminate\Support\Facades\App as AppFacade;
+use Laravel\Nova\Fields\Heading;
+use ReflectionMethod;
+use Tests\TestCase;
+use Wm\WmPackage\Models\App as PackageApp;
+
+class AppHomeLayerSortButtonTest extends TestCase
+{
+    public function test_home_tab_includes_sort_trigger_before_config_home_field(): void
+    {
+        AppFacade::setLocale('en');
+
+        $fields = $this->homeTabFields();
+        $configHomeIndex = $this->fieldIndexByAttribute($fields, 'config_home');
+
+        $this->assertNotFalse($configHomeIndex, 'The config_home field should exist in the home tab.');
+        $this->assertGreaterThan(0, $configHomeIndex, 'The sort trigger should be inserted before config_home.');
+        $this->assertInstanceOf(Heading::class, $fields[$configHomeIndex - 1]);
+
+        $markup = $fields[$configHomeIndex - 1]->name;
+
+        $this->assertStringContainsString('Sort Home Layers', $markup);
+        $this->assertStringContainsString('Sort Layers A-Z', $markup);
+        $this->assertStringContainsString('data-config-home-sort-trigger="true"', $markup);
+        $this->assertStringContainsString('data-config-home-sort-attribute="config_home"', $markup);
+        $this->assertStringContainsString(
+            'data-config-home-sort-success="Layers sorted alphabetically within each group."',
+            $markup
+        );
+    }
+
+    public function test_home_tab_sort_trigger_uses_italian_translations(): void
+    {
+        AppFacade::setLocale('it');
+
+        $fields = $this->homeTabFields();
+        $configHomeIndex = $this->fieldIndexByAttribute($fields, 'config_home');
+
+        $this->assertNotFalse($configHomeIndex, 'The config_home field should exist in the home tab.');
+
+        $markup = $fields[$configHomeIndex - 1]->name;
+
+        $this->assertStringContainsString('Ordina i layer della home', $markup);
+        $this->assertStringContainsString('Ordina layer A-Z', $markup);
+        $this->assertStringContainsString(
+            'data-config-home-sort-info="I layer sono gia ordinati per ogni gruppo."',
+            $markup
+        );
+        $this->assertStringContainsString(
+            'Ordina alfabeticamente solo i box Layer consecutivi.',
+            $markup
+        );
+    }
+
+    private function homeTabFields(): array
+    {
+        $resource = new NovaAppResource(new PackageApp([
+            'id' => 123,
+            'name' => 'Test App',
+        ]));
+
+        $method = new ReflectionMethod($resource, 'home_tab');
+        $method->setAccessible(true);
+
+        return $method->invoke($resource);
+    }
+
+    private function fieldIndexByAttribute(array $fields, string $attribute): ?int
+    {
+        foreach ($fields as $index => $field) {
+            if (($field->attribute ?? null) === $attribute) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/ConfigHomeSorterScriptTest.php
+++ b/tests/Unit/ConfigHomeSorterScriptTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Unit;
+
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+class ConfigHomeSorterScriptTest extends TestCase
+{
+    public function test_sorter_script_orders_only_consecutive_layer_groups_and_uses_trigger_messages(): void
+    {
+        $tempScript = tempnam(sys_get_temp_dir(), 'config-home-sorter-test-');
+        $sorterPath = base_path('resources/js/nova/config-home-sorter.js');
+
+        $harness = <<<'JS'
+const fs = require('fs');
+
+const sorterScript = fs.readFileSync(process.argv[2], 'utf8');
+const documentListeners = {};
+const windowListeners = {};
+const mixins = [];
+const notifications = [];
+
+class MockElement {
+    constructor(attributes = {}) {
+        this.attributes = attributes;
+    }
+
+    closest(selector) {
+        return selector === '[data-config-home-sort-trigger="true"]' ? this : null;
+    }
+
+    getAttribute(name) {
+        return this.attributes[name] || null;
+    }
+}
+
+global.Element = MockElement;
+global.document = {
+    addEventListener(type, handler) {
+        documentListeners[type] = handler;
+    },
+    getElementById() {
+        return null;
+    },
+};
+
+global.window = {
+    addEventListener(type, handler) {
+        windowListeners[type] = handler;
+    },
+    dispatchEvent(event) {
+        if (windowListeners[event.type]) {
+            windowListeners[event.type](event);
+        }
+    },
+};
+
+global.CustomEvent = function CustomEvent(type, init = {}) {
+    this.type = type;
+    this.detail = init.detail;
+};
+
+global.Nova = {
+    booting(callback) {
+        callback({
+            mixin(definition) {
+                mixins.push(definition);
+            },
+        });
+    },
+    success(message) {
+        notifications.push(['success', message]);
+    },
+    info(message) {
+        notifications.push(['info', message]);
+    },
+    error(message) {
+        notifications.push(['error', message]);
+    },
+};
+
+eval(sorterScript);
+
+const mixin = mixins[0];
+const options = [
+    { value: 1, label: 'Alpha' },
+    { value: 2, label: 'Beta' },
+    { value: 3, label: 'Charlie' },
+    { value: 4, label: 'Delta' },
+    { value: 5, label: 'Echo' },
+];
+
+const vm = {
+    currentField: { attribute: 'config_home' },
+    resourceName: 'apps',
+    resourceId: 42,
+    order: ['title-1', 'layer-c', 'layer-a', 'slug-1', 'layer-d', 'layer-b', 'title-2', 'layer-e'],
+    groups: {
+        'title-1': { key: 'title-1', name: 'title', fields: [] },
+        'layer-c': { key: 'layer-c', name: 'layer', fields: [{ attribute: 'layer-c__layer', name: 'Layer', value: 3, options }] },
+        'layer-a': { key: 'layer-a', name: 'layer', fields: [{ attribute: 'layer-a__layer', name: 'Layer', value: 1, options }] },
+        'slug-1': { key: 'slug-1', name: 'slug', fields: [] },
+        'layer-d': { key: 'layer-d', name: 'layer', fields: [{ attribute: 'layer-d__layer', name: 'Layer', value: 4, options }] },
+        'layer-b': { key: 'layer-b', name: 'layer', fields: [{ attribute: 'layer-b__layer', name: 'Layer', value: 2, options }] },
+        'title-2': { key: 'title-2', name: 'title', fields: [] },
+        'layer-e': { key: 'layer-e', name: 'layer', fields: [{ attribute: 'layer-e__layer', name: 'Layer', value: 5, options }] },
+    },
+};
+
+mixin.mounted.call(vm);
+
+const clickEvent = {
+    target: new MockElement({
+        'data-config-home-sort-attribute': 'config_home',
+        'data-config-home-sort-success': 'Sorted ok',
+        'data-config-home-sort-info': 'Already sorted',
+        'data-config-home-sort-error': 'Sorter missing',
+    }),
+    preventDefault() {},
+};
+
+documentListeners.click(clickEvent);
+const firstOrder = [...vm.order];
+
+documentListeners.click(clickEvent);
+
+console.log(JSON.stringify({ firstOrder, notifications }));
+JS;
+
+        file_put_contents($tempScript, $harness);
+
+        $process = new Process(['node', $tempScript, $sorterPath], base_path());
+        $process->run();
+
+        @unlink($tempScript);
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            trim($process->getErrorOutput()."\n".$process->getOutput())
+        );
+
+        $result = json_decode(trim($process->getOutput()), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(
+            ['title-1', 'layer-a', 'layer-c', 'slug-1', 'layer-b', 'layer-d', 'title-2', 'layer-e'],
+            $result['firstOrder']
+        );
+        $this->assertSame(['success', 'Sorted ok'], $result['notifications'][0]);
+        $this->assertSame(['info', 'Already sorted'], $result['notifications'][1]);
+    }
+}


### PR DESCRIPTION
Introduces a new feature to sort home tab layers alphabetically within groups using a button trigger in the Nova interface. Includes JavaScript logic for sorting and relevant translations for both English and Italian. Tests are added to ensure functionality supports both languages.