### PR TITLE
feat: add BulkEditAction to EcPoi for admins OC:8133

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ La relazione user → layer è `$user->layers()` (`HasMany` via `user_id` su tab
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
+| BulkEditAction su EcPoi (global) | oc:8133 | `app/Nova/EcPoi.php` | `BulkEditAction(\App\Nova\EcPoi::class, ['global'])` registrata in `EcPoi::actions()` con canSee+canRun per Administrator; logica bulk in wm-package |
 | Home tab layer sorting | oc:7644 | `App\Nova\Layer`, `resources/js/nova/config-home-sorter.js` | Sorting layer nella home tab via Nova |
 | UGC email notifications | oc:7641 | `App\Observers\UgcObserver`, `App\Jobs\SendUgcReportMailJob` | Email al gestore del layer alla creazione di un UGC report |
 | UGC filtro layer e read/unread | oc:7640 | `App\Nova\UgcPoi`, `App\Models\UgcPoi`, `App\Policies\UgcPoiPolicy`, `App\Nova\Actions\MarkAsRead`, `App\Nova\Actions\MarkAsUnread` | Validator vede solo segnalazioni dei propri layer; badge e action bulk letto/non letto |

--- a/app/Http/Controllers/LayerFeatureController.php
+++ b/app/Http/Controllers/LayerFeatureController.php
@@ -4,9 +4,11 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Models\User;
 use Wm\WmPackage\Nova\Fields\LayerFeatures\Http\Controllers\LayerFeatureController as WmLayerFeatureController;
 
 class LayerFeatureController extends WmLayerFeatureController
@@ -39,7 +41,7 @@ class LayerFeatureController extends WmLayerFeatureController
             }
 
             // Ottieni l'utente loggato
-            /** @var \Wm\WmPackage\Models\User|null $user */
+            /** @var User|null $user */
             $user = Auth::user();
 
             // Funzione helper per caricare le features associate
@@ -100,7 +102,7 @@ class LayerFeatureController extends WmLayerFeatureController
                 $paginatedFeatures = $allFeatures->slice($offset, $perPage);
 
                 // Crea un oggetto paginazione manuale
-                $features = new \Illuminate\Pagination\LengthAwarePaginator(
+                $features = new LengthAwarePaginator(
                     $paginatedFeatures,
                     $total,
                     $perPage,

--- a/app/Mail/NewUgcReportMail.php
+++ b/app/Mail/NewUgcReportMail.php
@@ -8,7 +8,9 @@ use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 use Wm\WmPackage\Models\Abstracts\GeometryModel;
+use Wm\WmPackage\Models\App;
 use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Models\UgcPoi;
 use Wm\WmPackage\Services\GeometryComputationService;
 
 class NewUgcReportMail extends Mailable
@@ -28,7 +30,7 @@ class NewUgcReportMail extends Mailable
         public readonly ?Layer $layer,
         public readonly bool $noOwner = false,
     ) {
-        $resourceName = $ugcPoi instanceof \Wm\WmPackage\Models\UgcPoi ? 'ugc-pois' : 'ugc-tracks';
+        $resourceName = $ugcPoi instanceof UgcPoi ? 'ugc-pois' : 'ugc-tracks';
         $this->novaUrl = rtrim(config('app.url'), '/').'/nova/resources/'.$resourceName.'/'.$ugcPoi->id;
         $this->coordinates = $this->extractCoordinates($ugcPoi);
         app()->setLocale('it');
@@ -56,7 +58,7 @@ class NewUgcReportMail extends Mailable
         $skipKeys = ['id', 'index', 'layer_id'];
         $locale = app()->getLocale();
 
-        $app = \Wm\WmPackage\Models\App::find($ugc->app_id);
+        $app = App::find($ugc->app_id);
         $formId = $form['id'] ?? null;
         $schema = ($app && $formId) ? ($app->acquisitionForms($formId) ?? []) : [];
 

--- a/app/Models/EcPoi.php
+++ b/app/Models/EcPoi.php
@@ -3,12 +3,13 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Wm\WmPackage\Database\Factories\EcPoiFactory;
 use Wm\WmPackage\Models\EcPoi as WmEcPoi;
 
 class EcPoi extends WmEcPoi
 {
     protected static function newFactory(): Factory
     {
-        return \Wm\WmPackage\Database\Factories\EcPoiFactory::new();
+        return EcPoiFactory::new();
     }
 }

--- a/app/Models/EcTrack.php
+++ b/app/Models/EcTrack.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Auth;
+use Wm\WmPackage\Database\Factories\EcTrackFactory;
 use Wm\WmPackage\Models\App;
 use Wm\WmPackage\Models\EcTrack as WmEcTrack;
 use Wm\WmPackage\Observers\EcTrackObserver;
@@ -12,7 +13,7 @@ class EcTrack extends WmEcTrack
 {
     protected static function newFactory(): Factory
     {
-        return \Wm\WmPackage\Database\Factories\EcTrackFactory::new();
+        return EcTrackFactory::new();
     }
 
     /**
@@ -30,7 +31,7 @@ class EcTrack extends WmEcTrack
             }
 
             // Se l'utente è un Validator, imposta automaticamente se stesso
-            /** @var \App\Models\User|null $currentUser */
+            /** @var User|null $currentUser */
             $currentUser = Auth::user();
             if (empty($ecTrack->user_id) && $currentUser) {
                 if ($currentUser->hasRole('Validator')) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Nova\Auth\Impersonatable;
@@ -9,7 +10,7 @@ use Wm\WmPackage\Models\User as WmUser;
 
 class User extends WmUser
 {
-    /** @use HasFactory<\Database\Factories\UserFactory> */
+    /** @use HasFactory<UserFactory> */
     use HasFactory, Impersonatable, Notifiable;
 
     /**

--- a/app/Nova/Dashboards/Main.php
+++ b/app/Nova/Dashboards/Main.php
@@ -2,6 +2,7 @@
 
 namespace App\Nova\Dashboards;
 
+use Laravel\Nova\Card;
 use Laravel\Nova\Cards\Help;
 use Laravel\Nova\Dashboards\Main as Dashboard;
 
@@ -10,7 +11,7 @@ class Main extends Dashboard
     /**
      * Get the cards for the dashboard.
      *
-     * @return array<int, \Laravel\Nova\Card>
+     * @return array<int, Card>
      */
     public function cards(): array
     {

--- a/app/Nova/EcPoi.php
+++ b/app/Nova/EcPoi.php
@@ -5,6 +5,7 @@ namespace App\Nova;
 use App\Models\EcPoi as EcPoiModel;
 use Illuminate\Http\Request;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Wm\WmPackage\Nova\Actions\BulkEditAction;
 use Wm\WmPackage\Nova\Actions\DownloadEcPoiAction;
 use Wm\WmPackage\Nova\Actions\ExecuteEcPoiDataChainAction;
 use Wm\WmPackage\Nova\Actions\TranslateModelAction;
@@ -49,6 +50,9 @@ class EcPoi extends WmNovaEcPoi
                 ->canSee(fn () => $isAdmin)
                 ->canRun(fn ($req, $model) => $isAdmin),
             (new TranslateModelAction)
+                ->canSee(fn () => $isAdmin)
+                ->canRun(fn ($req, $model) => $isAdmin),
+            (new BulkEditAction(self::class, ['global']))
                 ->canSee(fn () => $isAdmin)
                 ->canRun(fn ($req, $model) => $isAdmin),
         ];

--- a/app/Nova/Layer.php
+++ b/app/Nova/Layer.php
@@ -2,6 +2,7 @@
 
 namespace App\Nova;
 
+use App\Models\User;
 use App\Nova\Traits\FiltersUsersByRoleTrait;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Nova\Fields\BelongsTo;
@@ -22,7 +23,7 @@ class Layer extends WmNovaLayer
      */
     public static function indexQuery(NovaRequest $request, $query)
     {
-        /** @var \App\Models\User|null $user */
+        /** @var User|null $user */
         $user = Auth::user();
 
         if ($user && ! $user->hasRole('Administrator')) {

--- a/app/Nova/Tile.php
+++ b/app/Nova/Tile.php
@@ -5,4 +5,3 @@ namespace App\Nova;
 use Wm\WmPackage\Nova\Tile as WmNovaTile;
 
 class Tile extends WmNovaTile {}
-

--- a/app/Policies/LayerPolicy.php
+++ b/app/Policies/LayerPolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
 use Wm\WmPackage\Models\Layer;
 
 class LayerPolicy
@@ -30,7 +31,7 @@ class LayerPolicy
     /**
      * Determine whether the user can view any models.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function viewAny(User $user)
     {
@@ -40,7 +41,7 @@ class LayerPolicy
     /**
      * Determine whether the user can view the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function view(User $user, Layer $layer)
     {
@@ -50,7 +51,7 @@ class LayerPolicy
     /**
      * Determine whether the user can create models.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function create(User $user)
     {
@@ -60,7 +61,7 @@ class LayerPolicy
     /**
      * Determine whether the user can update the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function update(User $user, Layer $layer)
     {
@@ -74,7 +75,7 @@ class LayerPolicy
     /**
      * Determine whether the user can delete the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function delete(User $user, Layer $layer)
     {
@@ -88,7 +89,7 @@ class LayerPolicy
     /**
      * Determine whether the user can restore the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function restore(User $user, Layer $layer)
     {
@@ -98,7 +99,7 @@ class LayerPolicy
     /**
      * Determine whether the user can permanently delete the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function forceDelete(User $user, Layer $layer)
     {

--- a/app/Policies/TaxonomyPoiTypePolicy.php
+++ b/app/Policies/TaxonomyPoiTypePolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Models\TaxonomyPoiType;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
 
 class TaxonomyPoiTypePolicy
 {
@@ -26,7 +27,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can view any models.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function viewAny(User $user)
     {
@@ -37,7 +38,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can view the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function view(User $user, TaxonomyPoiType|\Laravel\Nova\Resource $taxonomyPoiType): bool
     {
@@ -47,7 +48,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can create models.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function create(User $user)
     {
@@ -58,7 +59,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can update the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function update(User $user, TaxonomyPoiType|\Laravel\Nova\Resource $taxonomyPoiType): bool
     {
@@ -68,7 +69,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can delete the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function delete(User $user, TaxonomyPoiType|\Laravel\Nova\Resource $taxonomyPoiType)
     {
@@ -78,7 +79,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can restore the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function restore(User $user, TaxonomyPoiType|\Laravel\Nova\Resource $taxonomyPoiType)
     {
@@ -88,7 +89,7 @@ class TaxonomyPoiTypePolicy
     /**
      * Determine whether the user can permanently delete the model.
      *
-     * @return \Illuminate\Auth\Access\Response|bool
+     * @return Response|bool
      */
     public function forceDelete(User $user, TaxonomyPoiType|\Laravel\Nova\Resource $taxonomyPoiType)
     {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -37,7 +37,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Gate::policy(\Wm\WmPackage\Models\UgcPoi::class, UgcPoiPolicy::class);
+        Gate::policy(UgcPoi::class, UgcPoiPolicy::class);
         Gate::policy(Layer::class, LayerPolicy::class);
         Gate::policy(Role::class, RolePolicy::class);
         Gate::policy(Permission::class, PermissionPolicy::class);

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -22,11 +22,13 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
+use Laravel\Nova\Dashboard;
 use Laravel\Nova\Events\ServingNova;
 use Laravel\Nova\Menu\MenuItem;
 use Laravel\Nova\Menu\MenuSection;
 use Laravel\Nova\Nova;
 use Laravel\Nova\NovaApplicationServiceProvider;
+use Laravel\Nova\Tool;
 use Wm\WmPackage\Services\RolesAndPermissionsService;
 
 class NovaServiceProvider extends NovaApplicationServiceProvider
@@ -137,19 +139,19 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
     /**
      * Get the dashboards that should be listed in the Nova sidebar.
      *
-     * @return array<int, \Laravel\Nova\Dashboard>
+     * @return array<int, Dashboard>
      */
     protected function dashboards(): array
     {
         return [
-            new \App\Nova\Dashboards\Main,
+            new Main,
         ];
     }
 
     /**
      * Get the tools that should be listed in the Nova sidebar.
      *
-     * @return array<int, \Laravel\Nova\Tool>
+     * @return array<int, Tool>
      */
     public function tools(): array
     {

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,8 +1,13 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+use App\Providers\HorizonServiceProvider;
+use App\Providers\NovaServiceProvider;
+use App\Providers\TelescopeServiceProvider;
+
 return [
-    App\Providers\AppServiceProvider::class,
-    App\Providers\HorizonServiceProvider::class,
-    App\Providers\NovaServiceProvider::class,
-    App\Providers\TelescopeServiceProvider::class,
+    AppServiceProvider::class,
+    HorizonServiceProvider::class,
+    NovaServiceProvider::class,
+    TelescopeServiceProvider::class,
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\User;
+
 return [
 
     /*
@@ -66,7 +68,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            'model' => env('AUTH_MODEL', User::class),
         ],
 
         // 'users' => [

--- a/config/jwt.php
+++ b/config/jwt.php
@@ -1,5 +1,9 @@
 <?php
 
+use Tymon\JWTAuth\Providers\Auth\Illuminate;
+use Tymon\JWTAuth\Providers\JWT\Lcobucci;
+use Tymon\JWTAuth\Providers\JWT\Provider;
+
 /*
  * This file is part of jwt-auth.
  *
@@ -131,7 +135,7 @@ return [
     |
     */
 
-    'algo' => env('JWT_ALGO', Tymon\JWTAuth\Providers\JWT\Provider::ALGO_HS256),
+    'algo' => env('JWT_ALGO', Provider::ALGO_HS256),
 
     /*
     |--------------------------------------------------------------------------
@@ -272,7 +276,7 @@ return [
         |
         */
 
-        'jwt' => Tymon\JWTAuth\Providers\JWT\Lcobucci::class,
+        'jwt' => Lcobucci::class,
 
         /*
         |--------------------------------------------------------------------------
@@ -283,7 +287,7 @@ return [
         |
         */
 
-        'auth' => Tymon\JWTAuth\Providers\Auth\Illuminate::class,
+        'auth' => Illuminate::class,
 
         /*
         |--------------------------------------------------------------------------

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,12 +2,13 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<User>
  */
 class UserFactory extends Factory
 {

--- a/database/migrations/2026_05_28_075533_zz_2026_04_23_120000_create_tiles_table.php
+++ b/database/migrations/2026_05_28_075533_zz_2026_04_23_120000_create_tiles_table.php
@@ -25,9 +25,9 @@ return new class extends Migration
             ['attribution' => 'webmapp'],
             [
                 'label' => json_encode(['it' => 'Webmapp', 'en' => 'Webmapp'], JSON_UNESCAPED_UNICODE),
-                'icon' => "tile-default",
+                'icon' => 'tile-default',
                 'server_xyz' => 'https://api.webmapp.it/tiles/{z}/{x}/{y}.png',
-                'link' => "https://webmapp.it/",
+                'link' => 'https://webmapp.it/',
                 'created_at' => $now,
                 'updated_at' => $now,
             ]
@@ -37,7 +37,7 @@ return new class extends Migration
             ['attribution' => 'mute'],
             [
                 'label' => json_encode(['it' => 'Mute', 'en' => 'Mute'], JSON_UNESCAPED_UNICODE),
-                'icon' => "tile-mute",
+                'icon' => 'tile-mute',
                 'server_xyz' => 'http://tiles.webmapp.it/blankmap/{z}/{x}/{y}.png',
                 'link' => null,
                 'created_at' => $now,
@@ -49,7 +49,7 @@ return new class extends Migration
             ['attribution' => 'satellite'],
             [
                 'label' => json_encode(['it' => 'Satellite', 'en' => 'Satellite'], JSON_UNESCAPED_UNICODE),
-                'icon' => "tile-satellite",
+                'icon' => 'tile-satellite',
                 'server_xyz' => 'https://api.maptiler.com/tiles/satellite/{z}/{x}/{y}.jpg?key=0Z7ou7nfFFXipdDXHChf',
                 'link' => null,
                 'created_at' => $now,
@@ -63,4 +63,3 @@ return new class extends Migration
         Schema::dropIfExists('tiles');
     }
 };
-

--- a/database/migrations/2026_05_28_075534_zz_2026_04_23_120100_create_app_tile_table.php
+++ b/database/migrations/2026_05_28_075534_zz_2026_04_23_120100_create_app_tile_table.php
@@ -69,4 +69,3 @@ return new class extends Migration
         Schema::dropIfExists('app_tile');
     }
 };
-

--- a/tests/Feature/EcPoiNovaActionsTest.php
+++ b/tests/Feature/EcPoiNovaActionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\EcPoi;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
@@ -26,7 +27,7 @@ class EcPoiNovaActionsTest extends TestCase
         $admin = User::factory()->create();
         $admin->assignRole('Administrator');
 
-        return \App\Models\EcPoi::factory()->create(['user_id' => $admin->id, 'properties' => []]);
+        return EcPoi::factory()->create(['user_id' => $admin->id, 'properties' => []]);
     }
 
     public function test_validator_cannot_see_modifying_actions(): void

--- a/tests/Feature/EcPoiPolicyTest.php
+++ b/tests/Feature/EcPoiPolicyTest.php
@@ -3,12 +3,12 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Wm\WmPackage\Models\EcPoi;
 use App\Policies\EcPoiPolicy;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Gate;
 use Tests\TestCase;
 use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\EcPoi;
 use Wm\WmPackage\Services\RolesAndPermissionsService;
 
 class EcPoiPolicyTest extends TestCase
@@ -46,7 +46,7 @@ class EcPoiPolicyTest extends TestCase
 
     public function test_local_ecpoi_policy_is_registered(): void
     {
-        $policy = Gate::getPolicyFor(\Wm\WmPackage\Models\EcPoi::class);
+        $policy = Gate::getPolicyFor(EcPoi::class);
         $this->assertInstanceOf(EcPoiPolicy::class, $policy);
     }
 
@@ -55,7 +55,7 @@ class EcPoiPolicyTest extends TestCase
     public function test_administrator_can_view_any_ec_poi(): void
     {
         $admin = $this->makeUser('Administrator');
-        $this->assertTrue(Gate::forUser($admin)->allows('viewAny', \Wm\WmPackage\Models\EcPoi::class));
+        $this->assertTrue(Gate::forUser($admin)->allows('viewAny', EcPoi::class));
     }
 
     public function test_administrator_can_view_ec_poi(): void
@@ -68,7 +68,7 @@ class EcPoiPolicyTest extends TestCase
     public function test_administrator_can_create_ec_poi(): void
     {
         $admin = $this->makeUser('Administrator');
-        $this->assertTrue(Gate::forUser($admin)->allows('create', \Wm\WmPackage\Models\EcPoi::class));
+        $this->assertTrue(Gate::forUser($admin)->allows('create', EcPoi::class));
     }
 
     public function test_administrator_can_update_ec_poi(): void
@@ -90,7 +90,7 @@ class EcPoiPolicyTest extends TestCase
     public function test_validator_can_view_any_ec_poi(): void
     {
         $validator = $this->makeUser('Validator');
-        $this->assertTrue(Gate::forUser($validator)->allows('viewAny', \Wm\WmPackage\Models\EcPoi::class));
+        $this->assertTrue(Gate::forUser($validator)->allows('viewAny', EcPoi::class));
     }
 
     public function test_validator_can_view_ec_poi(): void
@@ -103,7 +103,7 @@ class EcPoiPolicyTest extends TestCase
     public function test_validator_cannot_create_ec_poi(): void
     {
         $validator = $this->makeUser('Validator');
-        $this->assertFalse(Gate::forUser($validator)->allows('create', \Wm\WmPackage\Models\EcPoi::class));
+        $this->assertFalse(Gate::forUser($validator)->allows('create', EcPoi::class));
     }
 
     public function test_validator_cannot_update_ec_poi(): void
@@ -125,7 +125,7 @@ class EcPoiPolicyTest extends TestCase
     public function test_guest_cannot_view_any_ec_poi(): void
     {
         $guest = $this->makeUser('Guest');
-        $this->assertFalse(Gate::forUser($guest)->allows('viewAny', \Wm\WmPackage\Models\EcPoi::class));
+        $this->assertFalse(Gate::forUser($guest)->allows('viewAny', EcPoi::class));
     }
 
     public function test_guest_cannot_view_ec_poi(): void

--- a/tests/Feature/LayerActionsVisibilityTest.php
+++ b/tests/Feature/LayerActionsVisibilityTest.php
@@ -3,11 +3,10 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Wm\WmPackage\Models\App;
-use Wm\WmPackage\Models\Layer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use Wm\WmPackage\Nova\Actions\AddLayersToConfigHomeAction;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\Layer;
 use Wm\WmPackage\Services\RolesAndPermissionsService;
 
 class LayerActionsVisibilityTest extends TestCase

--- a/tests/Feature/UgcNotificationTest.php
+++ b/tests/Feature/UgcNotificationTest.php
@@ -14,6 +14,7 @@ use Wm\WmPackage\Models\Layer;
 use Wm\WmPackage\Models\UgcPoi;
 use Wm\WmPackage\Models\User;
 use Wm\WmPackage\Services\RolesAndPermissionsService;
+use Wm\WmPackage\Services\UgcService;
 
 class UgcNotificationTest extends TestCase
 {
@@ -95,7 +96,7 @@ class UgcNotificationTest extends TestCase
             'properties' => ['form' => ['id' => 'poi']],
         ]);
 
-        (new ResolveUgcLayerJob($ugcPoi))->handle(app(\Wm\WmPackage\Services\UgcService::class));
+        (new ResolveUgcLayerJob($ugcPoi))->handle(app(UgcService::class));
 
         Mail::assertNothingSent();
     }

--- a/tests/Feature/UgcPoiIndexQueryTest.php
+++ b/tests/Feature/UgcPoiIndexQueryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Laravel\Nova\Http\Requests\NovaRequest;
 use Tests\Feature\Helpers\LayerTestHelpers;
 use Tests\TestCase;
 use Wm\WmPackage\Models\App as WmApp;
@@ -50,7 +51,7 @@ class UgcPoiIndexQueryTest extends TestCase
         $report = $this->createReportPoi($layer->id);
         $poi = $this->createPoiUgc($layer->id);
 
-        $request = \Laravel\Nova\Http\Requests\NovaRequest::create('/');
+        $request = NovaRequest::create('/');
         $request->setUserResolver(fn () => $admin);
 
         $results = \App\Nova\UgcPoi::indexQuery($request, UgcPoi::query())->get();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Tests\TestCase;
+
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -11,7 +13,7 @@
 |
 */
 
-pest()->extend(Tests\TestCase::class)
+pest()->extend(TestCase::class)
  // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Feature');
 


### PR DESCRIPTION
Introduce BulkEditAction for `EcPoi` in the Nova admin interface. Allows administrators to perform global bulk edits, enhancing their efficiency in managing points of interest.