### PR TITLE
fix(oc:8140): add FixEcPoiLayersProperty command + review fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,8 +108,16 @@ La relazione user → layer è `$user->layers()` (`HasMany` via `user_id` su tab
 | EcPoi: sola lettura per Validator | oc:8120 | `App\Policies\EcPoiPolicy`, `App\Providers\AppServiceProvider`, `App\Nova\EcPoi` | Validator può solo visualizzare EcPoi; Guest bloccato in Nova; action di modifica nascoste con canSee+canRun |
 | Fix UI layer owner: action e link occhio tracce | oc:8089 | `App\Nova\Layer`, `tests/Feature/LayerActionsVisibilityTest.php`, `wm-package/.../LayerFeatures.php`, `wm-package/.../useGrid.ts` | canSee+canRun su AddLayersToConfigHomeAction (solo Administrator); novaPath via withMeta per link icona occhio corretto |
 | Associazione automatica EcPoi al layer della traccia | oc:8139 | `wm-package/.../EcPoiEcTrackObserver.php`, `wm-package/.../Layer.php`, `wm-package/.../EcPoi.php`, `wm-package/.../Nova/Layer.php`, `App\Observers\LayerableObserver`, `App\Observers\LayerObserver`, `App\Console\Commands\SyncLayerEcPois` | EcPoi sincronizzati automaticamente ai layer della traccia; command di migrazione dati storici; panel EcPoi in Nova Layer |
+| Fix properties.layers EcPoi corrotto per layer senza taxonomy_where | oc:8140 | `wm-package/src/Services/Models/LayerService.php`, `App\Console\Commands\FixEcPoiLayersProperty`, `tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php` | Guard in `updateLayersPropertyOnLayeredFeature`: salta add e pulisce stale IDs quando layer non ha manuali né filtri tassonomici; command di riallineamento dati storici |
 
 ## Decisioni architetturali
+
+### Fix properties.layers EcPoi (oc:8140)
+- `updateLayersPropertyOnLayeredFeature` usa un flag `$noValidFilter` (no manual models AND no taxonomy_where AND no taxonomyActivities) invece di un early return — così il path di rimozione gira comunque e pulisce i layer ID storicamente corrotti (`$layerFeaturesIds = []` → `whereNotIn([])` seleziona tutti i POI con quell'ID → vengono rimossi)
+- I test per questa logica stanno nel repo principale (`tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php`) e NON in `wm-package/tests/` — i test del wm-package non possono referenziare `Tests\TestCase` del repo principale, e `Wm\WmPackage\Tests\TestCase` non è in `autoload-dev` di camminiditalia
+- Il `layerable_type` nel DB per EcPoi è `'App\Models\EcPoi'` (chiave del morph map), non `Wm\WmPackage\Models\EcPoi::class` — da usare nei test che inseriscono direttamente in `layerables`
+- Ordine obbligatorio di esecuzione in produzione: (1) deploy fix wm-package, (2) backup DB, (3) `sync-layer-ec-pois`, (4) `fix-ec-poi-layers-property` — il terzo popola `layerables`, il quarto usa `layerables` come sorgente di verità per aggiornare `properties['layers']`
+- `fix-ec-poi-layers-property` ha un self-check pre-deploy e flag `--force` per bypassarlo consapevolmente
 
 ### EcPoi: sola lettura per Validator (oc:8120)
 - `authorizedToCreate` su una Nova Resource è metodo **statico** — `authorizedToUpdate` e `authorizedToDelete` sono di istanza

--- a/app/Console/Commands/FixEcPoiLayersProperty.php
+++ b/app/Console/Commands/FixEcPoiLayersProperty.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 use Wm\WmPackage\Models\Layer;
 use Wm\WmPackage\Services\Models\LayerService;
 
@@ -11,8 +12,9 @@ class FixEcPoiLayersProperty extends Command
     protected $signature = 'camminiditalia:fix-ec-poi-layers-property
                             {--force : Bypassa il check di pre-deploy (usa solo se il fix in wm-package è confermato deployato)}';
 
-    protected $description = 'Riallinea properties.layers su EcPoi e EcTrack per tutti i layer, rimuovendo ID errati e aggiungendo quelli mancanti.
-    IMPORTANTE: eseguire DOPO il deploy del fix in wm-package (oc:8140). Fare un backup del DB prima di procedere.';
+    protected $description = 'Riallinea properties.layers su EcPoi e EcTrack per tutti i layer.';
+
+    protected $help = 'IMPORTANTE: eseguire DOPO il deploy del fix in wm-package (oc:8140). Fare un backup del DB prima di procedere.';
 
     public function handle(LayerService $layerService): int
     {
@@ -60,7 +62,6 @@ class FixEcPoiLayersProperty extends Command
 
     private function guardIsInPlace(LayerService $layerService): bool
     {
-        // Trova un layer senza taxonomy_where, senza taxonomyActivities, senza modelli manuali
         $candidate = Layer::with(['taxonomyActivities'])
             ->whereDoesntHave('taxonomyActivities')
             ->get()
@@ -69,17 +70,25 @@ class FixEcPoiLayersProperty extends Command
             });
 
         if (! $candidate) {
-            // Non c'è un layer idoneo per il check — assumi che il guard sia in place
             return true;
         }
 
-        foreach ($layerService->getModelsWithLayersInProperties() as $modelClass) {
-            $result = $layerService->updateLayersPropertyOnLayeredFeature($candidate, $modelClass);
-            if (! empty($result['added'])) {
-                return false;
+        // Esegui la verifica dentro una transazione che viene annullata: il metodo scrive nel DB
+        // (beginTransaction + saveQuietly), ma il rollBack esterno annulla tutto tramite savepoint PostgreSQL.
+        $isInPlace = true;
+        DB::beginTransaction();
+        try {
+            foreach ($layerService->getModelsWithLayersInProperties() as $modelClass) {
+                $result = $layerService->updateLayersPropertyOnLayeredFeature($candidate, $modelClass);
+                if (! empty($result['added'])) {
+                    $isInPlace = false;
+                    break;
+                }
             }
+        } finally {
+            DB::rollBack();
         }
 
-        return true;
+        return $isInPlace;
     }
 }

--- a/app/Console/Commands/FixEcPoiLayersProperty.php
+++ b/app/Console/Commands/FixEcPoiLayersProperty.php
@@ -54,7 +54,7 @@ class FixEcPoiLayersProperty extends Command
         });
 
         $this->newLine(2);
-        $this->info("Riallineamento completato.");
+        $this->info('Riallineamento completato.');
         $this->line("Totale aggiunte: {$totalAdded} | Totale rimozioni: {$totalDeleted}");
 
         return self::SUCCESS;

--- a/app/Console/Commands/FixEcPoiLayersProperty.php
+++ b/app/Console/Commands/FixEcPoiLayersProperty.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Services\Models\LayerService;
+
+class FixEcPoiLayersProperty extends Command
+{
+    protected $signature = 'camminiditalia:fix-ec-poi-layers-property
+                            {--force : Bypassa il check di pre-deploy (usa solo se il fix in wm-package è confermato deployato)}';
+
+    protected $description = 'Riallinea properties.layers su EcPoi e EcTrack per tutti i layer, rimuovendo ID errati e aggiungendo quelli mancanti.
+    IMPORTANTE: eseguire DOPO il deploy del fix in wm-package (oc:8140). Fare un backup del DB prima di procedere.';
+
+    public function handle(LayerService $layerService): int
+    {
+        if (! $this->option('force') && ! $this->guardIsInPlace($layerService)) {
+            $this->error('Il fix in wm-package (oc:8140) non sembra deployato.');
+            $this->line('LayerService::updateLayersPropertyOnLayeredFeature() sta ancora processando layer senza filtri.');
+            $this->line('Esegui il deploy del fix, poi rilancia questo command.');
+            $this->line('Per bypassare questo controllo usa --force (solo se sai cosa fai).');
+
+            return self::FAILURE;
+        }
+
+        $layers = Layer::with(['taxonomyActivities'])->get();
+        $modelClasses = $layerService->getModelsWithLayersInProperties();
+
+        $this->info("Riallineamento properties.layers su {$layers->count()} layer × ".count($modelClasses).' model class...');
+        $this->newLine();
+
+        $totalAdded = 0;
+        $totalDeleted = 0;
+
+        $this->withProgressBar($layers, function (Layer $layer) use ($layerService, $modelClasses, &$totalAdded, &$totalDeleted) {
+            foreach ($modelClasses as $modelClass) {
+                $result = $layerService->updateLayersPropertyOnLayeredFeature($layer, $modelClass);
+
+                $added = count($result['added']);
+                $deleted = count($result['deleted']);
+                $totalAdded += $added;
+                $totalDeleted += $deleted;
+
+                if ($added > 0 || $deleted > 0) {
+                    $this->newLine();
+                    $modelName = class_basename($modelClass);
+                    $this->line("  [{$layer->getStringName()}] {$modelName}: +{$added} / -{$deleted}");
+                }
+            }
+        });
+
+        $this->newLine(2);
+        $this->info("Riallineamento completato.");
+        $this->line("Totale aggiunte: {$totalAdded} | Totale rimozioni: {$totalDeleted}");
+
+        return self::SUCCESS;
+    }
+
+    private function guardIsInPlace(LayerService $layerService): bool
+    {
+        // Trova un layer senza taxonomy_where, senza taxonomyActivities, senza modelli manuali
+        $candidate = Layer::with(['taxonomyActivities'])
+            ->whereDoesntHave('taxonomyActivities')
+            ->get()
+            ->first(function (Layer $layer) {
+                return empty($layer->properties['taxonomy_where'] ?? []);
+            });
+
+        if (! $candidate) {
+            // Non c'è un layer idoneo per il check — assumi che il guard sia in place
+            return true;
+        }
+
+        foreach ($layerService->getModelsWithLayersInProperties() as $modelClass) {
+            $result = $layerService->updateLayersPropertyOnLayeredFeature($candidate, $modelClass);
+            if (! empty($result['added'])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/docs/features/8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where/notes.md
+++ b/docs/features/8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where/notes.md
@@ -1,0 +1,42 @@
+> Ticket: oc:8140
+
+# Notes — Fix: properties.layers su EcPoi valorizzato erroneamente per layer senza taxonomy_where
+
+## Deviazioni dal piano
+
+- **Test spostati dal wm-package al repo principale**: il plan prevedeva i test in `wm-package/tests/Feature/`. Impossibile: wm-package non può referenziare `Tests\TestCase` del repo principale, e `Wm\WmPackage\Tests\TestCase` non è in `autoload-dev` di camminiditalia. Test spostati in `tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php` — più corretto perché testano il comportamento nel contesto di camminiditalia (morph map `App\Models\EcPoi`, factory locali, ecc.).
+
+- **Scope esteso a EcTrack**: il ticket menzionava solo EcPoi, ma il bug era identico per EcTrack (stessa call chain). Applicare il guard a entrambi elimina la biforcazione e il rischio di regressione futura su EcTrack. Confermato con l'utente durante la fase di design.
+
+## Bug trovati
+
+- **Morph type nel test**: il `layerable_type` da usare nel DB è `'App\Models\EcPoi'` (chiave del morph map), NON `Wm\WmPackage\Models\EcPoi::class`. Inserire il tipo sbagliato causa un falso negativo nel test (relazione `ecPois` non trova il POI).
+
+- **Guard con early return bloccava anche il path di rimozione**: la prima implementazione usava `return ['added' => [], 'deleted' => []]` per i layer senza filtri. Questo saltava anche il path che rimuove layer ID storicamente corrotti da `properties['layers']`. Verificato su dati reali: EcPoi #422 aveva `properties.layers: [32,24]` ma `layerables: [24]` — Layer 32 (0 manuali, 0 filtri) non veniva mai pulito. Fix: sostituito l'early return con flag `$noValidFilter` che azzera solo `$newLayerFeatures` (nessuna aggiunta) e `$layerFeaturesIds = []` (il path remove pulisce tutti i POI che hanno ancora quel layer ID). Risultato finale: 1350 rimozioni di falsi positivi, media layer/POI scesa da 6,02 a 1,04.
+
+## Decisioni
+
+- **Guard solo in scrittura** (`updateLayersPropertyOnLayeredFeature`), non nelle letture (`getAllVisibleModels`): Nova continua a mostrare i POI geograficamente visibili per un layer anche se non partecipa all'aggiornamento di `properties['layers']`.
+- **`taxonomyActivities->isNotEmpty()`** invece di `taxonomyActivities()->exists()`: usa la collection già caricata via eager loading nel command, evitando N+1 query.
+- **Command con self-check pre-deploy**: il command verifica che il guard sia in place prima di procedere; `--force` per bypassare consapevolmente.
+
+## Follow-up
+
+- Il bug esiste anche per EcTrack su `properties['layers']`, ma le tracce hanno `assignTracksByTaxonomy` come meccanismo separato — da monitorare se i dati su EcTrack sono anch'essi corrotti dopo il command.
+- Fix della root cause profonda (`scopeByWhereProperty` che non aggiunge `WHERE false`) è fuori scope — da valutare in un ticket separato se emergono altri callers problematici.
+
+## Ordine di esecuzione in produzione
+
+`fix-ec-poi-layers-property` e `sync-layer-ec-pois` agiscono su tabelle diverse e devono girare in sequenza:
+
+| Command | Modifica | Non tocca |
+|---|---|---|
+| `sync-layer-ec-pois` | `layerables` (pivot) | `properties['layers']` |
+| `fix-ec-poi-layers-property` | `properties['layers']` | `layerables` |
+
+`fix-ec-poi-layers-property` legge `layerables` come sorgente di verità: se `layerables` è incompleto, anche `properties['layers']` risulterà incompleto. L'ordine corretto è:
+
+1. Deploy fix wm-package (guard)
+2. Backup DB
+3. `camminiditalia:sync-layer-ec-pois`
+4. `camminiditalia:fix-ec-poi-layers-property`

--- a/docs/features/8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where/overview.md
+++ b/docs/features/8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where/overview.md
@@ -1,0 +1,36 @@
+> Ticket: oc:8140
+
+# Fix: properties.layers su EcPoi valorizzato erroneamente per layer senza taxonomy_where
+
+## Cosa cambia
+
+Un command Artisan idempotente riallinea `properties['layers']` su tutti gli EcPoi, rimuovendo gli ID di layer errati accumulati dal bug e aggiungendo quelli mancanti. Il fix al codice risiede in `wm-package` (vedi `wm-package/docs/features/8140-.../overview.md`).
+
+## Perché
+
+Il dump di produzione mostra 435 EcPoi con `properties['layers']` corrotto: 403 hanno almeno un layer errato, media 6,02 layer/POI. Solo 11 layer hanno POI reali in `layerables`. Il dato storico deve essere riallineato dopo il deploy del fix in wm-package.
+
+## Requisiti
+
+- [ ] Command Artisan `camminiditalia:fix-ec-poi-layers-property` che chiama `LayerService::updateLayersPropertyOnLayeredFeature()` per tutti i layer e tutti i model class (EcPoi + EcTrack) — dopo il deploy del fix in wm-package
+- [ ] Il command è idempotente: rieseguirlo produce lo stesso risultato
+- [ ] Nessuna rigenerazione PBF nel command
+- [ ] Il command logga il risultato per layer (aggiunti / rimossi) usando `$layer->getStringName()` per audit post-esecuzione
+- [ ] Il command rifiuta l'esecuzione con messaggio esplicito se rilevato codice non-patchato (layer senza filtri e senza manuali viene processato = guard non in place); flag `--force` per bypassare il check
+- [ ] Registrazione del command in `app/Console/Kernel.php`
+
+## Rischi
+
+- **Esecuzione pre-deploy**: se il command gira prima del fix in wm-package, amplifica la corruzione. Il command blocca l'esecuzione se rileva il codice non patchato (flag `--force` per override consapevole).
+- **Nessun rollback automatico**: `properties` è JSONB, nessuna migration inversa. Eseguire un dump DB prima del command. In caso di corruzione, ripristinare dal dump.
+- **Durata**: 118 layer × logica add/remove — monitorare tempi in produzione (possibile esecuzione in coda).
+
+## Out of scope
+
+- Rigenerazione PBF dopo il riallineamento
+- Fix del codice (wm-package)
+
+## Moduli toccati
+
+- `app/Console/Commands/FixEcPoiLayersProperty.php` — command di riallineamento
+- `app/Console/Kernel.php` — registrazione command

--- a/docs/features/8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where/plan.md
+++ b/docs/features/8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where/plan.md
@@ -1,0 +1,202 @@
+> Ticket: oc:8140
+
+# Plan — Fix: properties.layers su EcPoi valorizzato erroneamente per layer senza taxonomy_where
+
+## Repo coinvolti
+- **wm-package** — fix guard in `LayerService`
+- **camminiditalia** (repo principale) — command di riallineamento
+
+---
+
+## Step 1 — Crea branch in wm-package
+
+```bash
+git -C wm-package checkout -b feature/oc-8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where
+```
+
+---
+
+## Step 2 — Crea branch nel repo principale
+
+```bash
+git checkout -b feature/oc-8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where
+```
+
+---
+
+## Step 3 — Fix in `LayerService` (wm-package)
+
+**File:** `wm-package/src/Services/Models/LayerService.php`
+
+### 3a — Aggiungi metodo privato `hasValidAutoModeFilter`
+
+```php
+private function hasValidAutoModeFilter(Layer $layer): bool
+{
+    return ! empty($layer->properties['taxonomy_where'] ?? [])
+        || $layer->taxonomyActivities->isNotEmpty();
+}
+```
+
+### 3b — Aggiungi guard all'inizio di `updateLayersPropertyOnLayeredFeature`
+
+Subito dopo la firma del metodo, prima di qualsiasi query:
+
+```php
+public function updateLayersPropertyOnLayeredFeature(Layer $layer, string $ecModelClass): array
+{
+    if (! $this->hasRelatedManualModels($layer, $ecModelClass) && ! $this->hasValidAutoModeFilter($layer)) {
+        return ['added' => [], 'deleted' => []];
+    }
+
+    // ... codice esistente invariato
+}
+```
+
+**Nota:** la guard usa `$layer->taxonomyActivities->isNotEmpty()` (accesso come property, non come query diretta) così beneficia dell'eager loading nel command senza fare query aggiuntive.
+
+---
+
+## Step 4 — Test del guard in wm-package
+
+**File da creare:** `wm-package/tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php`
+
+Namespace: `Wm\WmPackage\Tests\Feature`
+Usa: `DatabaseTransactions`, `LayerService`, `App`, `Layer`, `EcPoi` del package
+
+**Casi da coprire:**
+
+1. **`test_skips_update_when_layer_has_no_manual_models_and_no_taxonomy_filter`**
+   - Layer senza `taxonomy_where` in properties, senza `taxonomyActivities`, senza EcPoi in layerables
+   - EcPoi dello stesso app_id esistente
+   - Chiama `updateLayersPropertyOnLayeredFeature($layer, EcPoi::class)`
+   - Assert: ritorna `['added' => [], 'deleted' => []]`
+   - Assert: `properties['layers']` dell'EcPoi non contiene l'ID del layer
+
+2. **`test_updates_when_layer_has_manual_ec_poi`**
+   - Layer senza taxonomy filter ma con 1 EcPoi in layerables
+   - Chiama `updateLayersPropertyOnLayeredFeature($layer, EcPoi::class)`
+   - Assert: `added` contiene l'ID dell'EcPoi manuale
+
+3. **`test_updates_when_layer_has_taxonomy_where`**
+   - Layer con `properties['taxonomy_where']` valorizzato
+   - Chiama `updateLayersPropertyOnLayeredFeature($layer, EcPoi::class)`
+   - Assert: il metodo non fa early return (ritorna array con chiavi `added`/`deleted` anche se entrambi vuoti per mancanza di match tassonomici)
+
+4. **`test_updates_when_layer_has_taxonomy_activities`**
+   - Layer con almeno una `taxonomyActivity` associata via pivot
+   - Chiama `updateLayersPropertyOnLayeredFeature($layer, EcPoi::class)`
+   - Assert: il metodo non fa early return
+
+5. **`test_skips_update_for_ec_track_when_no_manual_models_and_no_filter`** *(regressione per EcTrack)*
+   - Stesso scenario del test 1 ma con `EcTrack::class`
+   - Assert: ritorna `['added' => [], 'deleted' => []]`
+
+Esegui i test con:
+```bash
+docker exec laravel-camminiditalia php artisan test wm-package/tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php
+```
+
+---
+
+## Step 5 — Command di riallineamento (repo principale)
+
+**File da creare:** `app/Console/Commands/FixEcPoiLayersProperty.php`
+
+```
+Signature: camminiditalia:fix-ec-poi-layers-property {--force : Bypassa il check di pre-deploy}
+Description: Riallinea properties.layers su EcPoi e EcTrack per tutti i layer
+```
+
+### Logica del command
+
+```
+1. Self-check (saltato con --force):
+   - Trova un layer senza taxonomy_where, senza taxonomyActivities, senza manuali
+   - Chiama updateLayersPropertyOnLayeredFeature su di esso
+   - Se 'added' non è vuoto → codice non patchato → abort con errore esplicito:
+     "Il fix in wm-package non è deployato. Esegui prima il deploy, poi riesegui il command.
+      Usa --force per bypassare questo controllo (solo se sai cosa fai)."
+
+2. Carica tutti i layer con eager loading:
+   Layer::with(['taxonomyActivities'])->get()
+
+3. Per ogni layer × ogni model class in LayerService::getModelsWithLayersInProperties():
+   - Chiama $layerService->updateLayersPropertyOnLayeredFeature($layer, $modelClass)
+   - Logga: "[Layer {$layer->getStringName()}] {$modelClass}: +{added} / -{deleted}"
+
+4. Output finale: "Riallineamento completato. Tot. layer: N, aggiunte: X, rimozioni: Y"
+```
+
+**Nota:** `$layer->getStringName()` invece di `$layer->name` (che restituisce stringa vuota per il cast).
+
+---
+
+## Step 6 — Registra il command
+
+**File:** `routes/console.php` (Laravel 11 — non `app/Console/Kernel.php`)
+
+Aggiungi:
+```php
+Artisan::command('camminiditalia:fix-ec-poi-layers-property ...', function () {
+    // oppure registra via discover automatico se il command è in app/Console/Commands/
+});
+```
+
+Il command viene auto-scoperto da Laravel 11 se in `app/Console/Commands/` — verifica che il bootstrap lo includa, altrimenti aggiungi esplicitamente in `routes/console.php`.
+
+---
+
+## Step 7 — Esegui i test di regressione
+
+```bash
+docker exec laravel-camminiditalia php artisan test
+```
+
+Verifica che nessun test esistente regredisca dopo la guard.
+
+---
+
+## Step 8 — Commit in wm-package
+
+```bash
+git -C wm-package add src/Services/Models/LayerService.php \
+    tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php \
+    docs/features/8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where/
+git -C wm-package commit -m "fix(oc:8140): skip updateLayersProperty when layer has no filters or manual models"
+```
+
+---
+
+## Step 9 — Commit nel repo principale
+
+```bash
+git add app/Console/Commands/FixEcPoiLayersProperty.php \
+    docs/features/8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where/
+git commit -m "fix(oc:8140): add FixEcPoiLayersProperty command for data realignment"
+```
+
+---
+
+## Step 10 — PR verso `develop`
+
+Apri due PR (una per wm-package, una per il repo principale) verso `develop`.
+
+---
+
+## Ordine di deploy in produzione
+
+1. Deploy wm-package (fix guard)
+2. Deploy repo principale (command)
+3. **Backup DB** — `properties` è JSONB senza migration inversa, non c'è rollback automatico
+4. Esegui `sync-layer-ec-pois` per assicurare che `layerables` abbia tutte le associazioni corrette:
+   ```bash
+   docker exec laravel-camminiditalia php artisan camminiditalia:sync-layer-ec-pois
+   ```
+5. Esegui `fix-ec-poi-layers-property` che usa `layerables` come sorgente di verità per aggiornare `properties['layers']`:
+   ```bash
+   docker exec laravel-camminiditalia php artisan camminiditalia:fix-ec-poi-layers-property
+   ```
+6. Verifica log output per audit
+
+> **Perché questo ordine?** `sync-layer-ec-pois` popola `layerables` (pivot) dai POI delle tracce. `fix-ec-poi-layers-property` legge `layerables` per aggiornare `properties['layers']`. Se salti il punto 4, il punto 5 aggiorna `properties['layers']` basandosi su `layerables` potenzialmente incompleti.

--- a/tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php
+++ b/tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php
@@ -149,5 +149,4 @@ class LayerServiceUpdateLayersPropertyGuardTest extends TestCase
         $this->assertArrayHasKey('added', $result);
         $this->assertArrayHasKey('deleted', $result);
     }
-
 }

--- a/tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php
+++ b/tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Assert;
+use Tests\TestCase;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\EcPoi;
+use Wm\WmPackage\Models\EcTrack;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Services\Models\LayerService;
+
+class LayerServiceUpdateLayersPropertyGuardTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private LayerService $layerService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->layerService = app(LayerService::class);
+    }
+
+    public function test_skips_adds_and_cleans_stale_ids_when_no_manual_models_and_no_taxonomy_filter(): void
+    {
+        $app = App::factory()->createQuietly();
+        $layer = Layer::factory()->createQuietly([
+            'app_id' => $app->id,
+            'properties' => [],
+        ]);
+
+        // POI che NON dovrebbe avere il layer (nessuna relazione manuale né taxonomy)
+        $poiWithout = EcPoi::factory()->createQuietly([
+            'app_id' => $app->id,
+            'properties' => ['layers' => []],
+        ]);
+
+        // POI con layer ID già corrotto in properties.layers (dato storico da pulire)
+        $poiStale = EcPoi::factory()->createQuietly([
+            'app_id' => $app->id,
+            'properties' => ['layers' => [$layer->id]],
+        ]);
+
+        $result = $this->layerService->updateLayersPropertyOnLayeredFeature($layer->fresh(), EcPoi::class);
+
+        // Nessuna aggiunta (guard blocca il path add)
+        Assert::assertSame([], $result['added']);
+
+        // Il POI con ID corrotto viene ripulito
+        Assert::assertContains($poiStale->id, $result['deleted']);
+
+        $poiStale->refresh();
+        Assert::assertNotContains($layer->id, $poiStale->properties['layers'] ?? []);
+
+        // Il POI senza relazione rimane invariato
+        $poiWithout->refresh();
+        Assert::assertNotContains($layer->id, $poiWithout->properties['layers'] ?? []);
+    }
+
+    public function test_skips_adds_for_ec_track_when_no_manual_models_and_no_filter(): void
+    {
+        $app = App::factory()->createQuietly();
+        $layer = Layer::factory()->createQuietly([
+            'app_id' => $app->id,
+            'properties' => [],
+        ]);
+
+        $trackStale = EcTrack::factory()->createQuietly([
+            'app_id' => $app->id,
+            'properties' => ['layers' => [$layer->id]],
+        ]);
+
+        $result = $this->layerService->updateLayersPropertyOnLayeredFeature($layer->fresh(), EcTrack::class);
+
+        Assert::assertSame([], $result['added']);
+        Assert::assertContains($trackStale->id, $result['deleted']);
+
+        $trackStale->refresh();
+        Assert::assertNotContains($layer->id, $trackStale->properties['layers'] ?? []);
+    }
+
+    public function test_updates_when_layer_has_manual_ec_poi(): void
+    {
+        $app = App::factory()->createQuietly();
+        $poi = EcPoi::factory()->createQuietly([
+            'app_id' => $app->id,
+            'properties' => ['layers' => []],
+        ]);
+        $layer = Layer::factory()->createQuietly([
+            'app_id' => $app->id,
+            'properties' => [],
+        ]);
+
+        // Il morph map traduce EcPoi::class -> 'App\Models\EcPoi' nella colonna layerable_type
+        DB::table('layerables')->insert([
+            'layer_id' => $layer->id,
+            'layerable_id' => $poi->id,
+            'layerable_type' => 'App\Models\EcPoi',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $result = $this->layerService->updateLayersPropertyOnLayeredFeature($layer->fresh(), EcPoi::class);
+
+        Assert::assertContains($poi->id, $result['added']);
+    }
+
+    public function test_updates_when_layer_has_taxonomy_where_in_properties(): void
+    {
+        $app = App::factory()->createQuietly();
+        $layer = Layer::factory()->createQuietly([
+            'app_id' => $app->id,
+            'properties' => ['taxonomy_where' => ['val1' => 'something']],
+        ]);
+
+        $result = $this->layerService->updateLayersPropertyOnLayeredFeature($layer->fresh(), EcPoi::class);
+
+        Assert::assertArrayHasKey('added', $result);
+        Assert::assertArrayHasKey('deleted', $result);
+    }
+
+    public function test_updates_when_layer_has_taxonomy_activities(): void
+    {
+        $app = App::factory()->createQuietly();
+        $layer = Layer::factory()->createQuietly(['app_id' => $app->id, 'properties' => []]);
+
+        $activityId = DB::table('taxonomy_activities')->insertGetId([
+            'name' => json_encode(['it' => 'test-activity-'.uniqid()]),
+            'description' => null,
+            'excerpt' => null,
+            'identifier' => 'test-'.uniqid(),
+            'properties' => json_encode([]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('taxonomy_activityables')->insert([
+            'taxonomy_activity_id' => $activityId,
+            'taxonomy_activityable_type' => Layer::class,
+            'taxonomy_activityable_id' => $layer->id,
+            'duration_forward' => 0,
+            'duration_backward' => 0,
+        ]);
+
+        $result = $this->layerService->updateLayersPropertyOnLayeredFeature($layer->fresh(), EcPoi::class);
+
+        Assert::assertArrayHasKey('added', $result);
+        Assert::assertArrayHasKey('deleted', $result);
+    }
+
+}

--- a/tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php
+++ b/tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\DB;
-use PHPUnit\Framework\Assert;
 use Tests\TestCase;
 use Wm\WmPackage\Models\App;
 use Wm\WmPackage\Models\EcPoi;
@@ -47,17 +46,17 @@ class LayerServiceUpdateLayersPropertyGuardTest extends TestCase
         $result = $this->layerService->updateLayersPropertyOnLayeredFeature($layer->fresh(), EcPoi::class);
 
         // Nessuna aggiunta (guard blocca il path add)
-        Assert::assertSame([], $result['added']);
+        $this->assertSame([], $result['added']);
 
         // Il POI con ID corrotto viene ripulito
-        Assert::assertContains($poiStale->id, $result['deleted']);
+        $this->assertContains($poiStale->id, $result['deleted']);
 
         $poiStale->refresh();
-        Assert::assertNotContains($layer->id, $poiStale->properties['layers'] ?? []);
+        $this->assertNotContains($layer->id, $poiStale->properties['layers'] ?? []);
 
         // Il POI senza relazione rimane invariato
         $poiWithout->refresh();
-        Assert::assertNotContains($layer->id, $poiWithout->properties['layers'] ?? []);
+        $this->assertNotContains($layer->id, $poiWithout->properties['layers'] ?? []);
     }
 
     public function test_skips_adds_for_ec_track_when_no_manual_models_and_no_filter(): void
@@ -75,11 +74,11 @@ class LayerServiceUpdateLayersPropertyGuardTest extends TestCase
 
         $result = $this->layerService->updateLayersPropertyOnLayeredFeature($layer->fresh(), EcTrack::class);
 
-        Assert::assertSame([], $result['added']);
-        Assert::assertContains($trackStale->id, $result['deleted']);
+        $this->assertSame([], $result['added']);
+        $this->assertContains($trackStale->id, $result['deleted']);
 
         $trackStale->refresh();
-        Assert::assertNotContains($layer->id, $trackStale->properties['layers'] ?? []);
+        $this->assertNotContains($layer->id, $trackStale->properties['layers'] ?? []);
     }
 
     public function test_updates_when_layer_has_manual_ec_poi(): void
@@ -105,7 +104,7 @@ class LayerServiceUpdateLayersPropertyGuardTest extends TestCase
 
         $result = $this->layerService->updateLayersPropertyOnLayeredFeature($layer->fresh(), EcPoi::class);
 
-        Assert::assertContains($poi->id, $result['added']);
+        $this->assertContains($poi->id, $result['added']);
     }
 
     public function test_updates_when_layer_has_taxonomy_where_in_properties(): void
@@ -118,8 +117,8 @@ class LayerServiceUpdateLayersPropertyGuardTest extends TestCase
 
         $result = $this->layerService->updateLayersPropertyOnLayeredFeature($layer->fresh(), EcPoi::class);
 
-        Assert::assertArrayHasKey('added', $result);
-        Assert::assertArrayHasKey('deleted', $result);
+        $this->assertArrayHasKey('added', $result);
+        $this->assertArrayHasKey('deleted', $result);
     }
 
     public function test_updates_when_layer_has_taxonomy_activities(): void
@@ -147,8 +146,8 @@ class LayerServiceUpdateLayersPropertyGuardTest extends TestCase
 
         $result = $this->layerService->updateLayersPropertyOnLayeredFeature($layer->fresh(), EcPoi::class);
 
-        Assert::assertArrayHasKey('added', $result);
-        Assert::assertArrayHasKey('deleted', $result);
+        $this->assertArrayHasKey('added', $result);
+        $this->assertArrayHasKey('deleted', $result);
     }
 
 }


### PR DESCRIPTION
## Summary

- Aggiunto command `camminiditalia:fix-ec-poi-layers-property` per riallineare `properties['layers']` su EcPoi e EcTrack dopo il deploy del fix in wm-package
- `guardIsInPlace()` wrappato in `DB::beginTransaction/rollBack` — la verifica pre-deploy non scrive mai dati reali in produzione
- Aggiunto `$help` per la descrizione multilinea del command (non visibile in `artisan list`)
- Test `LayerServiceUpdateLayersPropertyGuardTest` aggiornato allo stile `$this->assert*` del progetto

## Sequenza deploy in produzione

1. merge + deploy wm-package (PR #235)
2. merge + deploy camminiditalia (questa PR)
3. backup DB
4. `docker exec laravel-camminiditalia php artisan camminiditalia:sync-layer-ec-pois`
5. `docker exec laravel-camminiditalia php artisan camminiditalia:fix-ec-poi-layers-property`

## Test plan

- [ ] `php artisan test tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php` — 5 test verdi
- [ ] Test manuali in staging: verificare che `properties['layers']` sui EcPoi contenga solo i layer corretti dopo i due command

🤖 Generated with [Claude Code](https://claude.com/claude-code)