### PR TITLE
fix: rimuovi trait Impersonatable duplicato da App\Models\User

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,13 +5,12 @@ namespace App\Models;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Notifications\Notifiable;
-use Laravel\Nova\Auth\Impersonatable;
 use Wm\WmPackage\Models\User as WmUser;
 
 class User extends WmUser
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, Impersonatable, Notifiable;
+    use HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Nova/UgcPoi.php
+++ b/app/Nova/UgcPoi.php
@@ -14,8 +14,8 @@ use Wm\WmPackage\Nova\UgcPoi as WmNovaUgcPoi;
 
 class UgcPoi extends WmNovaUgcPoi
 {
-    use HidesAppFromIndexTrait;
     use HasLayerFilterAndLink;
+    use HidesAppFromIndexTrait;
 
     public static $model = \App\Models\UgcPoi::class;
 

--- a/app/Nova/UgcTrack.php
+++ b/app/Nova/UgcTrack.php
@@ -11,8 +11,8 @@ use Wm\WmPackage\Nova\UgcTrack as WmNovaUgcTrack;
 
 class UgcTrack extends WmNovaUgcTrack
 {
-    use HidesAppFromIndexTrait;
     use HasLayerFilterAndLink;
+    use HidesAppFromIndexTrait;
 
     public static function label(): string
     {

--- a/database/migrations/2026_07_13_141750_z_add_foreign_keys_to_taxonomy_themeables_table.php
+++ b/database/migrations/2026_07_13_141750_z_add_foreign_keys_to_taxonomy_themeables_table.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/tests/Feature/UgcPoiLayerFieldTest.php
+++ b/tests/Feature/UgcPoiLayerFieldTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
-use App\Models\User;
 use Wm\WmPackage\Models\App;
 use Wm\WmPackage\Models\Layer;
 use Wm\WmPackage\Models\UgcPoi;

--- a/tests/Feature/UgcTrackLayerFieldTest.php
+++ b/tests/Feature/UgcTrackLayerFieldTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
-use App\Models\User;
 use Wm\WmPackage\Models\App;
 use Wm\WmPackage\Models\Layer;
 use Wm\WmPackage\Models\UgcTrack;


### PR DESCRIPTION
## Summary
- Rimosso il trait `Laravel\Nova\Auth\Impersonatable` da `app/Models/User.php`, aggiunto localmente prima che `wm-package` implementasse la stessa funzionalità (oc:8231) sulla classe padre.
- `Wm\WmPackage\Models\User` ora dichiara `canImpersonate(): bool` — riapplicare il trait nel figlio causa un fatal error (`Impersonatable::canImpersonate() must be compatible with User::canImpersonate(): bool`) non appena il submodule aggiornato viene caricato.
- Effetto collaterale corretto: camminiditalia era rimasto sulla policy permissiva di default di Nova (chiunque con `viewNova` poteva impersonare chiunque) — ora eredita quella più restrittiva del package (solo Administrator, target richiede `access-nova`). Follow-up esplicitamente documentato in `wm-package/docs/features/8231-aggiungere-impersonate/overview.md`.

## Test plan
- [x] `php artisan test --filter=EcPoiPolicyTest` — 13/13 PASS (nessuna regressione generale)
- [x] `class_exists('App\Models\User')` verificato senza fatal error dopo il fix
- [x] `/nova/login` risponde 200 (prima 500)
- [x] Verificato via query DB che `access-nova` esiste ed è assegnato ad Administrator/Validator — nessuna dipendenza mancante

🤖 Generato con [Claude Code](https://claude.com/claude-code)