### PR TITLE
feat(oc:8304): gestione autonoma POI per gestori di cammino

### DIFF
--- a/app/Nova/EcPoi.php
+++ b/app/Nova/EcPoi.php
@@ -47,7 +47,10 @@ class EcPoi extends WmNovaEcPoi
             return true;
         }
 
-        return $user->hasRole('Validator') && $this->resource->user_id === $user->id;
+        /** @var EcPoiModel $ecPoi */
+        $ecPoi = $this->resource;
+
+        return $user->hasRole('Validator') && $ecPoi->user_id === $user->id;
     }
 
     public function authorizedToDelete(Request $request): bool

--- a/app/Nova/EcPoi.php
+++ b/app/Nova/EcPoi.php
@@ -4,7 +4,10 @@ namespace App\Nova;
 
 use App\Models\EcPoi as EcPoiModel;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Wm\WmPackage\Models\Layer;
 use Wm\WmPackage\Nova\Actions\BulkEditAction;
 use Wm\WmPackage\Nova\Actions\DownloadEcPoiAction;
 use Wm\WmPackage\Nova\Actions\ExecuteEcPoiDataChainAction;
@@ -23,17 +26,69 @@ class EcPoi extends WmNovaEcPoi
 
     public static function authorizedToCreate(Request $request): bool
     {
-        return $request->user()?->hasRole('Administrator') ?? false;
+        $user = $request->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        return $user->hasRole('Administrator') || ($user->hasRole('Validator') && $user->layers()->exists());
     }
 
     public function authorizedToUpdate(Request $request): bool
     {
-        return $request->user()?->hasRole('Administrator') ?? false;
+        $user = $request->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        if ($user->hasRole('Administrator')) {
+            return true;
+        }
+
+        return $user->hasRole('Validator') && $this->resource->user_id === $user->id;
     }
 
     public function authorizedToDelete(Request $request): bool
     {
         return $request->user()?->hasRole('Administrator') ?? false;
+    }
+
+    public function fields(NovaRequest $request): array
+    {
+        $fields = parent::fields($request);
+
+        if ($layerField = $this->layerAssignmentField($request)) {
+            $fields[] = $layerField;
+        }
+
+        return $fields;
+    }
+
+    private function layerAssignmentField(NovaRequest $request): ?Select
+    {
+        $user = $request->user();
+
+        if (! $user || ! $user->hasRole('Validator')) {
+            return null;
+        }
+
+        $layers = $user->layers()->get();
+
+        if ($layers->isEmpty()) {
+            return null;
+        }
+
+        $rules = $layers->count() > 1
+            ? ['required', Rule::in($layers->pluck('id')->toArray())]
+            : ['nullable', Rule::in($layers->pluck('id')->toArray())];
+
+        return Select::make(__('Layer'), 'properties->layer_id')
+            ->options($layers->mapWithKeys(fn (Layer $layer) => [$layer->id => $layer->getStringName()])->toArray())
+            ->rules(...$rules)
+            ->onlyOnForms()
+            ->hideWhenUpdating();
     }
 
     public function actions(NovaRequest $request): array

--- a/app/Observers/EcPoiValidatorLayerObserver.php
+++ b/app/Observers/EcPoiValidatorLayerObserver.php
@@ -3,6 +3,7 @@
 namespace App\Observers;
 
 use App\Models\User;
+use Illuminate\Support\Collection;
 use Wm\WmPackage\Models\EcPoi;
 use Wm\WmPackage\Models\Layer;
 
@@ -16,7 +17,7 @@ class EcPoiValidatorLayerObserver
             return;
         }
 
-        /** @var \Illuminate\Support\Collection<int, Layer> $layers */
+        /** @var Collection<int, Layer> $layers */
         $layers = $user->layers()->get();
 
         if ($layers->isEmpty()) {

--- a/app/Observers/EcPoiValidatorLayerObserver.php
+++ b/app/Observers/EcPoiValidatorLayerObserver.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Observers;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EcPoiValidatorLayerObserver
+{
+    public function created(Model $ecPoi): void
+    {
+        $user = $ecPoi->user_id ? \App\Models\User::find($ecPoi->user_id) : null;
+
+        if (! $user || ! $user->hasRole('Validator')) {
+            return;
+        }
+
+        $layers = $user->layers()->get();
+
+        if ($layers->isEmpty()) {
+            return;
+        }
+
+        if ($layers->count() === 1) {
+            $layers->first()->ecPois()->syncWithoutDetaching([$ecPoi->id]);
+
+            return;
+        }
+
+        $layerId = $ecPoi->properties['layer_id'] ?? null;
+
+        if (is_numeric($layerId) && $layers->pluck('id')->contains((int) $layerId)) {
+            $layers->firstWhere('id', (int) $layerId)?->ecPois()->syncWithoutDetaching([$ecPoi->id]);
+        }
+    }
+}

--- a/app/Observers/EcPoiValidatorLayerObserver.php
+++ b/app/Observers/EcPoiValidatorLayerObserver.php
@@ -3,11 +3,12 @@
 namespace App\Observers;
 
 use App\Models\User;
-use Illuminate\Database\Eloquent\Model;
+use Wm\WmPackage\Models\EcPoi;
+use Wm\WmPackage\Models\Layer;
 
 class EcPoiValidatorLayerObserver
 {
-    public function created(Model $ecPoi): void
+    public function created(EcPoi $ecPoi): void
     {
         $user = $ecPoi->user_id ? User::find($ecPoi->user_id) : null;
 
@@ -15,6 +16,7 @@ class EcPoiValidatorLayerObserver
             return;
         }
 
+        /** @var \Illuminate\Support\Collection<int, Layer> $layers */
         $layers = $user->layers()->get();
 
         if ($layers->isEmpty()) {

--- a/app/Observers/EcPoiValidatorLayerObserver.php
+++ b/app/Observers/EcPoiValidatorLayerObserver.php
@@ -2,13 +2,14 @@
 
 namespace App\Observers;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 
 class EcPoiValidatorLayerObserver
 {
     public function created(Model $ecPoi): void
     {
-        $user = $ecPoi->user_id ? \App\Models\User::find($ecPoi->user_id) : null;
+        $user = $ecPoi->user_id ? User::find($ecPoi->user_id) : null;
 
         if (! $user || ! $user->hasRole('Validator')) {
             return;

--- a/app/Policies/EcPoiPolicy.php
+++ b/app/Policies/EcPoiPolicy.php
@@ -35,12 +35,12 @@ class EcPoiPolicy
 
     public function create(User $user): bool
     {
-        return false;
+        return $user->layers()->exists();
     }
 
     public function update(User $user, EcPoi $ecPoi): bool
     {
-        return false;
+        return $ecPoi->user_id === $user->id;
     }
 
     public function delete(User $user, EcPoi $ecPoi): bool

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Models\TaxonomyPoiType;
+use App\Observers\EcPoiValidatorLayerObserver;
 use App\Observers\LayerableObserver;
 use App\Observers\LayerObserver;
 use App\Observers\UgcObserver;
@@ -48,5 +49,7 @@ class AppServiceProvider extends ServiceProvider
         UgcTrack::observe(UgcObserver::class);
         Layer::observe(LayerObserver::class);
         Layerable::observe(LayerableObserver::class);
+        EcPoi::observe(EcPoiValidatorLayerObserver::class);
+        \App\Models\EcPoi::observe(EcPoiValidatorLayerObserver::class);
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -11609,6 +11609,7 @@
                     "Wm\\WmPackage\\Database\\Factories\\": "database/factories/",
                     "Wm\\WmPackage\\Http\\Controllers\\": "src/Http/Controllers",
                     "Wm\\WmPackage\\Nova\\Fields\\IconSelect\\": "src/Nova/Fields/IconSelect/src/",
+                    "Wm\\WmPackage\\Nova\\Fields\\TranslationsBuilder\\": "src/Nova/Fields/TranslationsBuilder/src/",
                     "Wm\\WmPackage\\Nova\\Fields\\LayerFeatures\\": "src/Nova/Fields/LayerFeatures/src/",
                     "Wm\\WmPackage\\Nova\\Fields\\FeatureCollectionMap\\": "src/Nova/Fields/FeatureCollectionMap/src/",
                     "Wm\\WmPackage\\Nova\\Cards\\LayerAnalytics\\": "src/Nova/Cards/LayerAnalytics/src/",

--- a/docs/features/8304-gestione-autonoma-poi-gestori-cammino/overview.md
+++ b/docs/features/8304-gestione-autonoma-poi-gestori-cammino/overview.md
@@ -1,0 +1,55 @@
+> Ticket: oc:8304
+
+# Gestione autonoma POI da parte dei gestori di cammino
+
+## Cosa cambia
+
+Oggi i Validator (gestori di cammino) sono in sola lettura su EcPoi — decisione presa esplicitamente in oc:8120. Questa feature abilita i Validator a **creare e modificare** i propri EcPoi (il **delete resta esclusivo Administrator**, vedi Rischi):
+
+- In Nova, l'index EcPoi per un Validator mostra solo i POI con `user_id === $user->id`. Non serve un filtro basato su `$user->layers()` (join su `layerables`): per la proprietà transitiva già in vigore (`LayerObserver::saved` sincronizza `user_id` di tutti gli EcPoi con l'owner del layer al cambio owner), "POI dei propri layer" e "POI con `user_id` proprio" sono lo stesso insieme nella pratica di camminiditalia (dove i gestori di cammino non condividono POI tra loro) — filtrare per `user_id` è equivalente, più semplice e senza join.
+- Un Validator con **zero layer** non può creare EcPoi (`authorizedToCreate` → `false` in quel caso).
+- Un Validator con almeno un layer può creare un nuovo EcPoi. In creazione, il POI deve essere associato a un layer:
+  - se possiede **un solo layer**, il campo è precompilato/nascosto automaticamente (nessuna selezione richiesta);
+  - se ne possiede **più di uno**, viene mostrato un Select limitato ai propri layer (opzioni costruite da `$request->user()->layers()`).
+- Update su un EcPoi esistente è autorizzato se `EcPoi.user_id === Validator.id`. Delete resta autorizzato solo per Administrator.
+
+## Perché
+
+Più gestori di cammino hanno richiesto di poter gestire autonomamente i propri POI senza passare per un Administrator. La funzione è attualmente disabilitata by design (oc:8120): questa feature la re-abilita, ma con scoping per layer invece di sbloccarla globalmente.
+
+## Requisiti
+
+- [ ] `EcPoiPolicy::create` → `true` per Validator se ha almeno un layer, altrimenti `false` (era sempre `false`)
+- [ ] `EcPoiPolicy::update` → `true` per Validator se `$ecPoi->user_id === $user->id`, altrimenti `false`
+- [ ] `EcPoiPolicy::delete` → resta `false` per Validator, invariato (delete esclusivo Administrator)
+- [ ] `EcPoiPolicy::viewAny`/`view` restano `true` (nessuna modifica: la visibilità in Nova va scoperta via filtro query, non via policy `view`, coerente col pattern UgcPoi)
+- [ ] `App\Nova\EcPoi::authorizedToCreate` → `true` per Administrator, oppure Validator con almeno un layer (era solo Administrator)
+- [ ] `App\Nova\EcPoi::authorizedToUpdate` → `true` per Administrator, oppure Validator se `$this->resource->user_id === $request->user()->id`
+- [ ] `App\Nova\EcPoi::authorizedToDelete` → invariato, solo Administrator
+- [ ] Index EcPoi in Nova filtrato per Validator: solo POI con `user_id === $user->id` (nuovo metodo, stesso pattern strutturale di `UgcPoi::filteredQueryForValidator` ma su `user_id`, non su join layer — coerente con il criterio update)
+- [ ] Campo layer in creazione EcPoi:
+  - Validator con 1 layer → campo nascosto, valore precompilato con l'unico layer
+  - Validator con N layer → `Select` searchable limitato ai propri layer (opzioni da `$request->user()->layers()`), obbligatorio
+  - Administrator → comportamento invariato (nessun vincolo, o campo opzionale — da confermare in write-plan se già esiste un meccanismo equivalente lato Admin)
+- [ ] Validazione server-side sul campo layer in creazione: per un Validator, `Rule::in($request->user()->layers()->pluck('id'))` — chiude il gap per cui `POST nova-api/ec-pois` (route generica Nova) accetterebbe altrimenti un `layer_id` arbitrario, dato che `Select::fillAttributeFromRequest` non verifica il valore contro le opzioni dichiarate (verificato in `vendor/laravel/nova/src/Fields/Field.php`)
+- [ ] Alla creazione, il nuovo EcPoi viene associato al layer scelto tramite pivot `layerables` (stesso meccanismo usato da `LayerFeatures` sul lato Layer)
+- [ ] Le Nova Action attualmente riservate ad Administrator (`ExecuteEcPoiDataChainAction`, `UploadPoiFile`, `TranslateModelAction`, `BulkEditAction`) restano riservate ad Administrator — **fuori scope**, non richieste dal ticket
+- [ ] `DownloadEcPoiAction` resta disponibile senza modifiche (nessun controllo esplicito, già filtrato dal default Nova su `authorizedToUpdate`/`view` a seconda dell'action)
+
+## Rischi
+
+- **POI condivisi tra layer con owner diversi** (documentato in oc:8139: ownership last-write-wins): per POI condivisi, `user_id` non rappresenta fedelmente "appartiene ai miei layer" — un Validator potrebbe non poter modificare un POI comunque presente nel suo layer, o viceversa. **Rischio accettato**: su camminiditalia i gestori di cammino non hanno necessità operativa di condividere POI tra loro; l'Administrator resta comunque con visibilità e controllo completo su tutti i POI come fallback.
+- **Delete escluso dallo scope Validator** proprio per mitigare il rischio più grave individuato in challenge: `EcPoi` non ha `SoftDeletes` (verificato nel modello), quindi una delete errata o su un POI condiviso sarebbe definitiva e recuperabile solo da backup DB. Limitando il Validator a create/update, questo rischio non si applica.
+- **Coupling implicito non testato** tra questa policy e gli observer che sincronizzano `user_id` (`LayerObserver`, oc:8139/oc:8080): se in futuro quella logica cambia, l'equivalenza "user_id proprio = POI nei propri layer" può rompersi silenziosamente. Rischio noto, non mitigato in questo ciclo — nessun test cross-modulo previsto.
+- **Layer scelto in creazione non validato lato server oltre le opzioni del Select**: `POST nova-api/{resource}` è una route Nova generica esistente per ogni resource (verificato con `route:list`), quindi chiunque abbia una sessione Validator autenticata può invocarla direttamente con un `layer_id` arbitrario, bypassando il form. **Mitigato**: aggiunta `Rule::in()` esplicita sul salvataggio (vedi Requisiti) — costo minimo, chiude un gap di autorizzazione reale.
+
+## Out of scope
+
+- Le Nova Action bulk/import (`ExecuteEcPoiDataChainAction`, `UploadPoiFile`, `TranslateModelAction`, `BulkEditAction`) restano esclusive Administrator
+- Nessuna modifica al meccanismo di associazione automatica EcPoi↔Layer via taxonomy/traccia (oc:8139, oc:8140) — questa feature riguarda solo la creazione/modifica manuale da parte del Validator
+- Nessuna modifica al flusso di trasferimento ownership al cambio owner del layer (oc:8080) — resta invariato e continua a garantire la proprietà transitiva `user_id === layer owner`
+
+## Moduli toccati
+
+- `app/Policies/EcPoiPolicy.php` — create/update/delete abilitati per Validator con scoping su `user_id`
+- `app/Nova/EcPoi.php` — `authorizedToCreate/Update/Delete`, filtro index per Validator (`user_id`), campo layer in creazione

--- a/docs/features/8304-gestione-autonoma-poi-gestori-cammino/plan.md
+++ b/docs/features/8304-gestione-autonoma-poi-gestori-cammino/plan.md
@@ -1,0 +1,673 @@
+> Ticket: oc:8304
+
+# Gestione autonoma POI da parte dei gestori di cammino — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Abilitare i Validator (gestori di cammino) a creare e modificare i propri EcPoi in Nova, restando in sola lettura sul delete (esclusivo Administrator), con associazione al layer scelta/validata lato server.
+
+**Architecture:** Due file toccati nel repo principale (`app/Policies/EcPoiPolicy.php`, `app/Nova/EcPoi.php`), nessuna migration, nessun submodule. Il filtro index per Validator è **già implementato** e non richiede codice nuovo: `Wm\WmPackage\Nova\AbstractEcResource::indexQuery()` filtra automaticamente per `user_id === $user->id` ogni utente non-Administrator, sfruttando la colonna `user_id` già presente su `ec_pois`. Il lavoro reale si concentra su: (1) autorizzazioni policy/Nova, (2) campo Select layer in creazione con validazione server-side, (3) attach automatico alla pivot `layerables`.
+
+**Tech Stack:** Laravel 11, Laravel Nova 5, Pest/PHPUnit (namespace `Tests\TestCase`), Spatie Permission (ruoli `Administrator`/`Validator`/`Guest`).
+
+## Global Constraints
+
+- Nessuna migration DB — nessuno schema change necessario.
+- Delete di EcPoi resta **esclusivo Administrator** — non toccare `EcPoiPolicy::delete` né `App\Nova\EcPoi::authorizedToDelete`.
+- `Layer::getStringName()` va sempre usato per il nome leggibile del layer nelle opzioni Select — **mai** `$layer->name` (restituisce stringa vuota per via del cast, decisione già documentata in `CLAUDE.md`).
+- L'associazione EcPoi↔Layer alla creazione passa sempre da `$layer->ecPois()->syncWithoutDetaching([$poi->id])` (relazione `MorphToMany` via pivot `layerables`) — mai scrittura diretta sulla tabella pivot.
+- I test Feature del repo principale usano `Tests\TestCase` (namespace `Tests\Feature`), **non** `Wm\WmPackage\Tests\TestCase` — quest'ultima non è in `autoload-dev` di camminiditalia.
+- `EcPoi::factory()->create()` richiede sempre `'properties' => []` esplicito nei test, altrimenti l'observer del package fallisce con `TypeError` (decisione già documentata in `CLAUDE.md`, oc:8120).
+- Rischio accettato e fuori scope: POI condivisi tra più layer con owner diversi (last-write-wins su `user_id`, oc:8139) — nessuna gestione speciale richiesta, camminiditalia non ha questo caso d'uso operativo.
+- Fuori scope: nessuna modifica alle Nova Action `ExecuteEcPoiDataChainAction`, `UploadPoiFile`, `TranslateModelAction`, `BulkEditAction` (restano solo Administrator) né a `DownloadEcPoiAction`.
+
+---
+
+## Task 1: EcPoiPolicy — create/update per Validator
+
+**Files:**
+- Modify: `app/Policies/EcPoiPolicy.php`
+- Modify (test esistenti da aggiornare): `tests/Feature/EcPoiPolicyTest.php`
+
+**Interfaces:**
+- Consumes: `App\Models\User::layers()` (relazione `HasMany` già esistente su `Wm\WmPackage\Models\Layer`, via colonna `user_id`).
+- Produces: `EcPoiPolicy::create(User $user): bool`, `EcPoiPolicy::update(User $user, EcPoi $ecPoi): bool` — usati da Task 2 (Nova resource) e da `Fase: execution` per verificare coerenza Gate/Nova.
+
+- [ ] **Step 1: Aggiorna i test esistenti per il nuovo comportamento atteso**
+
+Sostituisci in `tests/Feature/EcPoiPolicyTest.php` i due test `test_validator_cannot_create_ec_poi` e `test_validator_cannot_update_ec_poi` (il comportamento cambia: create/update ora sono permessi in determinate condizioni) con questi:
+
+```php
+    // --- Validator: create/update sui propri POI, scoping per layer ---
+
+    public function test_validator_with_layer_can_create_ec_poi(): void
+    {
+        $validator = $this->makeUser('Validator');
+        \Wm\WmPackage\Models\Layer::factory()->create(['user_id' => $validator->id]);
+
+        $this->assertTrue(Gate::forUser($validator)->allows('create', EcPoi::class));
+    }
+
+    public function test_validator_without_layer_cannot_create_ec_poi(): void
+    {
+        $validator = $this->makeUser('Validator');
+
+        $this->assertFalse(Gate::forUser($validator)->allows('create', EcPoi::class));
+    }
+
+    public function test_validator_can_update_own_ec_poi(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $ecPoi = $this->makeEcPoi($validator->id);
+
+        $this->assertTrue(Gate::forUser($validator)->allows('update', $ecPoi));
+    }
+
+    public function test_validator_cannot_update_ec_poi_of_another_user(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $otherValidator = $this->makeUser('Validator');
+        $ecPoi = $this->makeEcPoi($otherValidator->id);
+
+        $this->assertFalse(Gate::forUser($validator)->allows('update', $ecPoi));
+    }
+```
+
+Mantieni invariato `test_validator_cannot_delete_ec_poi` (il delete resta bloccato, nessuna modifica).
+
+- [ ] **Step 2: Esegui i test per verificare che falliscano**
+
+```bash
+docker exec laravel-camminiditalia php artisan test tests/Feature/EcPoiPolicyTest.php
+```
+
+Expected: FAIL su `test_validator_with_layer_can_create_ec_poi` e `test_validator_can_update_own_ec_poi` (i metodi `create`/`update` restituiscono ancora sempre `false` per Validator).
+
+- [ ] **Step 3: Implementa la policy**
+
+Sostituisci in `app/Policies/EcPoiPolicy.php` i metodi `create` e `update`:
+
+```php
+    public function create(User $user): bool
+    {
+        return $user->layers()->exists();
+    }
+
+    public function update(User $user, EcPoi $ecPoi): bool
+    {
+        return $ecPoi->user_id === $user->id;
+    }
+```
+
+Il file completo risultante:
+
+```php
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Wm\WmPackage\Models\EcPoi;
+
+class EcPoiPolicy
+{
+    use HandlesAuthorization;
+
+    public function before(User $user, string $ability): ?bool
+    {
+        if ($user->hasRole('Administrator')) {
+            return true;
+        }
+
+        if (! $user->hasRole('Validator')) {
+            return false;
+        }
+
+        return null;
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, EcPoi $ecPoi): bool
+    {
+        return true;
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->layers()->exists();
+    }
+
+    public function update(User $user, EcPoi $ecPoi): bool
+    {
+        return $ecPoi->user_id === $user->id;
+    }
+
+    public function delete(User $user, EcPoi $ecPoi): bool
+    {
+        return false;
+    }
+}
+```
+
+- [ ] **Step 4: Esegui i test per verificare che passino**
+
+```bash
+docker exec laravel-camminiditalia php artisan test tests/Feature/EcPoiPolicyTest.php
+```
+
+Expected: PASS su tutti i test del file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Policies/EcPoiPolicy.php tests/Feature/EcPoiPolicyTest.php
+git commit -m "feat(oc:8304): consenti a Validator con layer di creare/aggiornare i propri EcPoi"
+```
+
+---
+
+## Task 2: App\Nova\EcPoi — authorizedToCreate/Update per Validator
+
+**Files:**
+- Modify: `app/Nova/EcPoi.php`
+- Test: `tests/Feature/EcPoiNovaAuthorizationTest.php` (nuovo file)
+
+**Interfaces:**
+- Consumes: `EcPoiPolicy::create`/`update` (Task 1) — Nova non chiama automaticamente la Policy per `authorizedToCreate`/`authorizedToUpdate` di una Resource: questi metodi vanno implementati esplicitamente e devono restare **coerenti** con la policy.
+- Produces: `App\Nova\EcPoi::authorizedToCreate(Request $request): bool` (statico), `App\Nova\EcPoi::authorizedToUpdate(Request $request): bool` (istanza) — usati dal form Nova per mostrare/nascondere i bottoni Create/Update, e da Task 3 per condizionare la visibilità del campo layer.
+
+- [ ] **Step 1: Scrivi il test che deve fallire**
+
+Crea `tests/Feature/EcPoiNovaAuthorizationTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\EcPoi;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Services\RolesAndPermissionsService;
+
+class EcPoiNovaAuthorizationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        RolesAndPermissionsService::seedDatabase();
+        if (App::count() === 0) {
+            App::factory()->create();
+        }
+    }
+
+    private function makeUser(string $role): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole($role);
+
+        return $user;
+    }
+
+    public function test_validator_with_layer_can_see_creation_fields(): void
+    {
+        $validator = $this->makeUser('Validator');
+        Layer::factory()->create(['user_id' => $validator->id]);
+
+        $response = $this->actingAs($validator)
+            ->getJson('/nova-api/ec-pois/creation-fields');
+
+        $response->assertOk();
+    }
+
+    public function test_validator_without_layer_cannot_see_creation_fields(): void
+    {
+        $validator = $this->makeUser('Validator');
+
+        $response = $this->actingAs($validator)
+            ->getJson('/nova-api/ec-pois/creation-fields');
+
+        $this->assertContains($response->status(), [403, 404]);
+    }
+
+    public function test_validator_can_update_own_ec_poi_via_nova(): void
+    {
+        $validator = $this->makeUser('Validator');
+        Layer::factory()->create(['user_id' => $validator->id]);
+        $ecPoi = EcPoi::factory()->create(['user_id' => $validator->id, 'properties' => []]);
+
+        $response = $this->actingAs($validator)
+            ->getJson('/nova-api/ec-pois/'.$ecPoi->id.'/update-fields');
+
+        $response->assertOk();
+    }
+
+    public function test_validator_cannot_update_ec_poi_of_another_user_via_nova(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $otherValidator = $this->makeUser('Validator');
+        $ecPoi = EcPoi::factory()->create(['user_id' => $otherValidator->id, 'properties' => []]);
+
+        $response = $this->actingAs($validator)
+            ->getJson('/nova-api/ec-pois/'.$ecPoi->id.'/update-fields');
+
+        $this->assertContains($response->status(), [403, 404]);
+    }
+
+    public function test_administrator_can_see_creation_fields(): void
+    {
+        $admin = $this->makeUser('Administrator');
+
+        $response = $this->actingAs($admin)
+            ->getJson('/nova-api/ec-pois/creation-fields');
+
+        $response->assertOk();
+    }
+}
+```
+
+- [ ] **Step 2: Esegui i test per verificare che falliscano**
+
+```bash
+docker exec laravel-camminiditalia php artisan test tests/Feature/EcPoiNovaAuthorizationTest.php
+```
+
+Expected: FAIL su `test_validator_with_layer_can_see_creation_fields` e `test_validator_can_update_own_ec_poi_via_nova` (oggi `authorizedToCreate`/`authorizedToUpdate` restituiscono `false` per qualsiasi Validator).
+
+- [ ] **Step 3: Implementa i metodi in App\Nova\EcPoi**
+
+Sostituisci in `app/Nova/EcPoi.php` i metodi `authorizedToCreate` e `authorizedToUpdate`:
+
+```php
+    public static function authorizedToCreate(Request $request): bool
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        return $user->hasRole('Administrator') || ($user->hasRole('Validator') && $user->layers()->exists());
+    }
+
+    public function authorizedToUpdate(Request $request): bool
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        if ($user->hasRole('Administrator')) {
+            return true;
+        }
+
+        return $user->hasRole('Validator') && $this->resource->user_id === $user->id;
+    }
+```
+
+`authorizedToDelete` resta invariato (solo Administrator, nessuna modifica).
+
+- [ ] **Step 4: Esegui i test per verificare che passino**
+
+```bash
+docker exec laravel-camminiditalia php artisan test tests/Feature/EcPoiNovaAuthorizationTest.php
+```
+
+Expected: PASS su tutti i test del file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Nova/EcPoi.php tests/Feature/EcPoiNovaAuthorizationTest.php
+git commit -m "feat(oc:8304): abilita create/update Nova per Validator con layer proprio"
+```
+
+---
+
+## Task 3: Campo layer in creazione + validazione server-side + attach a layerables
+
+**Files:**
+- Modify: `app/Nova/EcPoi.php`
+- Test: `tests/Feature/EcPoiLayerAssignmentTest.php` (nuovo file)
+
+**Interfaces:**
+- Consumes: `App\Nova\EcPoi::authorizedToCreate` (Task 2, per sapere se l'utente è un Validator autorizzato), `Layer::getStringName(): string`, `$user->layers(): HasMany`, `Layer::ecPois(): MorphToMany`.
+- Produces: nessuna interfaccia consumata da altri task — è l'ultimo task del piano.
+
+- [ ] **Step 1: Scrivi il test che deve fallire**
+
+Crea `tests/Feature/EcPoiLayerAssignmentTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Services\RolesAndPermissionsService;
+
+class EcPoiLayerAssignmentTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        RolesAndPermissionsService::seedDatabase();
+        if (App::count() === 0) {
+            App::factory()->create();
+        }
+    }
+
+    private function makeUser(string $role): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole($role);
+
+        return $user;
+    }
+
+    private function createEcPoiPayload(): array
+    {
+        return [
+            'name' => 'Test POI',
+            'global' => '1',
+        ];
+    }
+
+    public function test_validator_with_single_layer_creates_ec_poi_auto_assigned(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-api/ec-pois', $this->createEcPoiPayload());
+
+        $response->assertCreated();
+
+        $poiId = $response->json('id') ?? $response->json('resource.id');
+        $this->assertTrue($layer->ecPois()->where('ec_pois.id', $poiId)->exists());
+    }
+
+    public function test_validator_with_multiple_layers_must_choose_own_layer(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $layerA = Layer::factory()->create(['user_id' => $validator->id]);
+        $layerB = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $payload = $this->createEcPoiPayload();
+        $payload['properties->layer_id'] = (string) $layerB->id;
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-api/ec-pois', $payload);
+
+        $response->assertCreated();
+
+        $poiId = $response->json('id') ?? $response->json('resource.id');
+        $this->assertTrue($layerB->ecPois()->where('ec_pois.id', $poiId)->exists());
+        $this->assertFalse($layerA->ecPois()->where('ec_pois.id', $poiId)->exists());
+    }
+
+    public function test_validator_cannot_assign_layer_not_owned(): void
+    {
+        $validator = $this->makeUser('Validator');
+        Layer::factory()->create(['user_id' => $validator->id]);
+
+        $otherValidator = $this->makeUser('Validator');
+        $foreignLayer = Layer::factory()->create(['user_id' => $otherValidator->id]);
+
+        $payload = $this->createEcPoiPayload();
+        $payload['properties->layer_id'] = (string) $foreignLayer->id;
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-api/ec-pois', $payload);
+
+        $response->assertStatus(422);
+    }
+}
+```
+
+- [ ] **Step 2: Esegui i test per verificare che falliscano**
+
+```bash
+docker exec laravel-camminiditalia php artisan test tests/Feature/EcPoiLayerAssignmentTest.php
+```
+
+Expected: FAIL (il campo layer non esiste ancora, quindi nessun attach a `layerables` e nessuna validazione avviene).
+
+- [ ] **Step 3: Implementa il campo Select layer con validazione e l'attach automatico**
+
+Aggiungi in cima a `app/Nova/EcPoi.php` gli import necessari:
+
+```php
+use Illuminate\Validation\Rule;
+use Laravel\Nova\Fields\Select;
+use Wm\WmPackage\Models\Layer;
+```
+
+Aggiungi il metodo `fields()` (override) che inserisce il campo Select solo per Validator, prima delle azioni. Il file risultante:
+
+```php
+<?php
+
+namespace App\Nova;
+
+use App\Models\EcPoi as EcPoiModel;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Laravel\Nova\Fields\Select;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Nova\Actions\BulkEditAction;
+use Wm\WmPackage\Nova\Actions\DownloadEcPoiAction;
+use Wm\WmPackage\Nova\Actions\ExecuteEcPoiDataChainAction;
+use Wm\WmPackage\Nova\Actions\TranslateModelAction;
+use Wm\WmPackage\Nova\Actions\UploadPoiFile;
+use Wm\WmPackage\Nova\EcPoi as WmNovaEcPoi;
+
+class EcPoi extends WmNovaEcPoi
+{
+    public static $model = EcPoiModel::class;
+
+    public static function label(): string
+    {
+        return __('Pois');
+    }
+
+    public static function authorizedToCreate(Request $request): bool
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        return $user->hasRole('Administrator') || ($user->hasRole('Validator') && $user->layers()->exists());
+    }
+
+    public function authorizedToUpdate(Request $request): bool
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        if ($user->hasRole('Administrator')) {
+            return true;
+        }
+
+        return $user->hasRole('Validator') && $this->resource->user_id === $user->id;
+    }
+
+    public function authorizedToDelete(Request $request): bool
+    {
+        return $request->user()?->hasRole('Administrator') ?? false;
+    }
+
+    public function fields(NovaRequest $request): array
+    {
+        $fields = parent::fields($request);
+
+        if ($layerField = $this->layerAssignmentField($request)) {
+            $fields[] = $layerField;
+        }
+
+        return $fields;
+    }
+
+    private function layerAssignmentField(NovaRequest $request): ?Select
+    {
+        $user = $request->user();
+
+        if (! $user || ! $user->hasRole('Validator')) {
+            return null;
+        }
+
+        $layers = $user->layers()->get();
+
+        if ($layers->count() <= 1) {
+            return null;
+        }
+
+        return Select::make(__('Layer'), 'properties->layer_id')
+            ->options($layers->mapWithKeys(fn (Layer $layer) => [$layer->id => $layer->getStringName()])->toArray())
+            ->rules('required', Rule::in($layers->pluck('id')->toArray()))
+            ->onlyOnForms()
+            ->hideWhenUpdating();
+    }
+
+    public function actions(NovaRequest $request): array
+    {
+        $isAdmin = $request->user()?->hasRole('Administrator');
+
+        return [
+            (new ExecuteEcPoiDataChainAction)
+                ->canSee(fn () => $isAdmin)
+                ->canRun(fn ($req, $model) => $isAdmin),
+            new DownloadEcPoiAction,
+            (new UploadPoiFile)
+                ->standalone()
+                ->canSee(fn () => $isAdmin)
+                ->canRun(fn ($req, $model) => $isAdmin),
+            (new TranslateModelAction)
+                ->canSee(fn () => $isAdmin)
+                ->canRun(fn ($req, $model) => $isAdmin),
+            (new BulkEditAction(self::class, ['global']))
+                ->canSee(fn () => $isAdmin)
+                ->canRun(fn ($req, $model) => $isAdmin),
+        ];
+    }
+}
+```
+
+Nota: quando il Validator ha **un solo** layer, il campo non viene mostrato (`$layers->count() <= 1` → `null`) — serve comunque assegnare quel layer automaticamente. Aggiungi un Observer locale dedicato invece di gestirlo nel field (il field `layer_id` non è una colonna del modello, quindi non c'è nulla da "fillare" quando il campo è assente).
+
+Crea `app/Observers/EcPoiValidatorLayerObserver.php`:
+
+```php
+<?php
+
+namespace App\Observers;
+
+use Wm\WmPackage\Models\EcPoi;
+
+class EcPoiValidatorLayerObserver
+{
+    public function created(EcPoi $ecPoi): void
+    {
+        $user = $ecPoi->user_id ? \App\Models\User::find($ecPoi->user_id) : null;
+
+        if (! $user || ! $user->hasRole('Validator')) {
+            return;
+        }
+
+        $layers = $user->layers()->get();
+
+        if ($layers->isEmpty()) {
+            return;
+        }
+
+        if ($layers->count() === 1) {
+            $layers->first()->ecPois()->syncWithoutDetaching([$ecPoi->id]);
+
+            return;
+        }
+
+        $layerId = $ecPoi->properties['layer_id'] ?? null;
+
+        if (is_numeric($layerId) && $layers->pluck('id')->contains((int) $layerId)) {
+            $layers->firstWhere('id', (int) $layerId)?->ecPois()->syncWithoutDetaching([$ecPoi->id]);
+        }
+    }
+}
+```
+
+Nota sull'attributo del campo: `properties->layer_id` non è una colonna reale di `EcPoi` (`ec_pois` non ha colonna `layer_id`) — è la stessa dot-notation su colonna JSON già usata da altri campi del package (es. `Text::make(__('Contact email'), 'properties->contact_email')` in `wm-package/src/Nova/EcPoi.php`). Nova, in fase di fill, converte l'arrow-notation in un `Arr::set()` sull'array `properties` del modello: il valore finisce in `$ecPoi->properties['layer_id']`, letto già così dall'Observer sotto. **Il nome del campo del form (request key) è letteralmente la stringa `properties->layer_id`**, non `layer_id` semplice — da usare esattamente così nei payload di test in Step 1.
+
+Registra l'observer in `app/Providers/AppServiceProvider.php`, nel metodo `boot()` (accanto alle altre registrazioni `Gate::policy()`/observer esistenti):
+
+```php
+\Wm\WmPackage\Models\EcPoi::observe(\App\Observers\EcPoiValidatorLayerObserver::class);
+```
+
+- [ ] **Step 4: Esegui i test per verificare che passino**
+
+```bash
+docker exec laravel-camminiditalia php artisan test tests/Feature/EcPoiLayerAssignmentTest.php
+```
+
+Expected: PASS su tutti i test del file.
+
+- [ ] **Step 5: Esegui l'intera suite dei file toccati per verificare che non ci siano regressioni**
+
+```bash
+docker exec laravel-camminiditalia php artisan test tests/Feature/EcPoiPolicyTest.php tests/Feature/EcPoiNovaActionsTest.php tests/Feature/EcPoiNovaAuthorizationTest.php tests/Feature/EcPoiLayerAssignmentTest.php
+```
+
+Expected: PASS su tutti i file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Nova/EcPoi.php app/Observers/EcPoiValidatorLayerObserver.php app/Providers/AppServiceProvider.php tests/Feature/EcPoiLayerAssignmentTest.php
+git commit -m "feat(oc:8304): campo layer in creazione EcPoi per Validator, con validazione server-side e attach automatico a layerables"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (requisiti da `overview.md`):
+1. `EcPoiPolicy::create` → Task 1 ✅
+2. `EcPoiPolicy::update` → Task 1 ✅
+3. `EcPoiPolicy::delete` invariato → non toccato, verificato in Task 1 (test esistente mantenuto) ✅
+4. `viewAny`/`view` invariati → non toccati ✅
+5. `authorizedToCreate` → Task 2 ✅
+6. `authorizedToUpdate` → Task 2 ✅
+7. `authorizedToDelete` invariato → non toccato, riportato esplicitamente in Task 3 (file completo) ✅
+8. Filtro index Validator (`user_id`) → **già implementato** da `AbstractEcResource::indexQuery()`, nessun task necessario — documentato nell'Architecture e da riportare in `notes.md` come deviazione positiva dal piano originale (meno codice del previsto) ✅
+9. Campo layer condizionale (1 vs N layer) → Task 3 ✅
+10. Validazione server-side `Rule::in` → Task 3 ✅
+11. Attach a `layerables` → Task 3 (via Observer, non via field diretto — deviazione tecnica necessaria, documentare in `notes.md`) ✅
+
+**2. Placeholder scan:** nessun placeholder — ogni step ha codice completo, comandi espliciti.
+
+**3. Type consistency:** `authorizedToCreate(Request $request): bool` (statico) e `authorizedToUpdate(Request $request): bool` (istanza) usati identicamente in Task 2 e Task 3 (Task 3 riporta il file completo, coerente). `EcPoiValidatorLayerObserver::created(EcPoi $ecPoi): void` — nessun altro task ne dipende.
+
+**Nota per Fase: notes** — la deviazione più rilevante da segnalare a fine esecuzione: l'attach a `layerables` per il caso "1 solo layer" non può avvenire nel field Nova stesso (nessun dato lato client da leggere quando il campo è nascosto), quindi si usa un Observer su `created` che legge `properties->layer_id` (quando presente) o assegna automaticamente l'unico layer. Verificare in esecuzione che l'ordine `created` → lettura `properties` funzioni correttamente dato che altri observer del package (`AbstractObserver`) intervengono sullo stesso evento — testare con attenzione l'interazione se il test Step 4 di Task 3 fallisce in modo anomalo.

--- a/tests/Feature/EcPoiLayerAssignmentTest.php
+++ b/tests/Feature/EcPoiLayerAssignmentTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Services\RolesAndPermissionsService;
+
+class EcPoiLayerAssignmentTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        RolesAndPermissionsService::seedDatabase();
+        if (App::count() === 0) {
+            App::factory()->create();
+        }
+    }
+
+    private function makeUser(string $role): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole($role);
+
+        return $user;
+    }
+
+    private function createEcPoiPayload(User $user): array
+    {
+        return [
+            'name' => 'Test POI',
+            'global' => '1',
+            'app' => App::first()->id,
+            'user' => $user->id,
+            'geometry' => json_encode([
+                'type' => 'Point',
+                'coordinates' => [11.0, 43.0],
+            ]),
+        ];
+    }
+
+    public function test_validator_with_single_layer_creates_ec_poi_auto_assigned(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-api/ec-pois', $this->createEcPoiPayload($validator));
+
+        $response->assertCreated();
+
+        $poiId = $response->json('id') ?? $response->json('resource.id');
+        $this->assertTrue($layer->ecPois()->where('ec_pois.id', $poiId)->exists());
+    }
+
+    public function test_validator_with_multiple_layers_must_choose_own_layer(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $layerA = Layer::factory()->create(['user_id' => $validator->id]);
+        $layerB = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $payload = $this->createEcPoiPayload($validator);
+        $payload['properties->layer_id'] = (string) $layerB->id;
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-api/ec-pois', $payload);
+
+        $response->assertCreated();
+
+        $poiId = $response->json('id') ?? $response->json('resource.id');
+        $this->assertTrue($layerB->ecPois()->where('ec_pois.id', $poiId)->exists());
+        $this->assertFalse($layerA->ecPois()->where('ec_pois.id', $poiId)->exists());
+    }
+
+    public function test_validator_cannot_assign_layer_not_owned(): void
+    {
+        $validator = $this->makeUser('Validator');
+        Layer::factory()->create(['user_id' => $validator->id]);
+
+        $otherValidator = $this->makeUser('Validator');
+        $foreignLayer = Layer::factory()->create(['user_id' => $otherValidator->id]);
+
+        $payload = $this->createEcPoiPayload($validator);
+        $payload['properties->layer_id'] = (string) $foreignLayer->id;
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-api/ec-pois', $payload);
+
+        $response->assertStatus(422);
+    }
+}

--- a/tests/Feature/EcPoiNovaAuthorizationTest.php
+++ b/tests/Feature/EcPoiNovaAuthorizationTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\EcPoi;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Services\RolesAndPermissionsService;
+
+class EcPoiNovaAuthorizationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        RolesAndPermissionsService::seedDatabase();
+        if (App::count() === 0) {
+            App::factory()->create();
+        }
+    }
+
+    private function makeUser(string $role): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole($role);
+
+        return $user;
+    }
+
+    public function test_validator_with_layer_can_see_creation_fields(): void
+    {
+        $validator = $this->makeUser('Validator');
+        Layer::factory()->create(['user_id' => $validator->id]);
+
+        $response = $this->actingAs($validator)
+            ->getJson('/nova-api/ec-pois/creation-fields');
+
+        $response->assertOk();
+    }
+
+    public function test_validator_without_layer_cannot_see_creation_fields(): void
+    {
+        $validator = $this->makeUser('Validator');
+
+        $response = $this->actingAs($validator)
+            ->getJson('/nova-api/ec-pois/creation-fields');
+
+        $this->assertContains($response->status(), [403, 404]);
+    }
+
+    public function test_validator_can_update_own_ec_poi_via_nova(): void
+    {
+        $validator = $this->makeUser('Validator');
+        Layer::factory()->create(['user_id' => $validator->id]);
+        $ecPoi = EcPoi::factory()->create(['user_id' => $validator->id, 'properties' => []]);
+
+        $response = $this->actingAs($validator)
+            ->getJson('/nova-api/ec-pois/'.$ecPoi->id.'/update-fields');
+
+        $response->assertOk();
+    }
+
+    public function test_validator_cannot_update_ec_poi_of_another_user_via_nova(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $otherValidator = $this->makeUser('Validator');
+        $ecPoi = EcPoi::factory()->create(['user_id' => $otherValidator->id, 'properties' => []]);
+
+        $response = $this->actingAs($validator)
+            ->getJson('/nova-api/ec-pois/'.$ecPoi->id.'/update-fields');
+
+        $this->assertContains($response->status(), [403, 404]);
+    }
+
+    public function test_administrator_can_see_creation_fields(): void
+    {
+        $admin = $this->makeUser('Administrator');
+
+        $response = $this->actingAs($admin)
+            ->getJson('/nova-api/ec-pois/creation-fields');
+
+        $response->assertOk();
+    }
+}

--- a/tests/Feature/EcPoiPolicyTest.php
+++ b/tests/Feature/EcPoiPolicyTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Gate;
 use Tests\TestCase;
 use Wm\WmPackage\Models\App;
 use Wm\WmPackage\Models\EcPoi;
+use Wm\WmPackage\Models\Layer;
 use Wm\WmPackage\Services\RolesAndPermissionsService;
 
 class EcPoiPolicyTest extends TestCase
@@ -105,7 +106,7 @@ class EcPoiPolicyTest extends TestCase
     public function test_validator_with_layer_can_create_ec_poi(): void
     {
         $validator = $this->makeUser('Validator');
-        \Wm\WmPackage\Models\Layer::factory()->create(['user_id' => $validator->id]);
+        Layer::factory()->create(['user_id' => $validator->id]);
 
         $this->assertTrue(Gate::forUser($validator)->allows('create', EcPoi::class));
     }

--- a/tests/Feature/EcPoiPolicyTest.php
+++ b/tests/Feature/EcPoiPolicyTest.php
@@ -100,16 +100,37 @@ class EcPoiPolicyTest extends TestCase
         $this->assertTrue(Gate::forUser($validator)->allows('view', $ecPoi));
     }
 
-    public function test_validator_cannot_create_ec_poi(): void
+    // --- Validator: create/update sui propri POI, scoping per layer ---
+
+    public function test_validator_with_layer_can_create_ec_poi(): void
     {
         $validator = $this->makeUser('Validator');
+        \Wm\WmPackage\Models\Layer::factory()->create(['user_id' => $validator->id]);
+
+        $this->assertTrue(Gate::forUser($validator)->allows('create', EcPoi::class));
+    }
+
+    public function test_validator_without_layer_cannot_create_ec_poi(): void
+    {
+        $validator = $this->makeUser('Validator');
+
         $this->assertFalse(Gate::forUser($validator)->allows('create', EcPoi::class));
     }
 
-    public function test_validator_cannot_update_ec_poi(): void
+    public function test_validator_can_update_own_ec_poi(): void
     {
         $validator = $this->makeUser('Validator');
         $ecPoi = $this->makeEcPoi($validator->id);
+
+        $this->assertTrue(Gate::forUser($validator)->allows('update', $ecPoi));
+    }
+
+    public function test_validator_cannot_update_ec_poi_of_another_user(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $otherValidator = $this->makeUser('Validator');
+        $ecPoi = $this->makeEcPoi($otherValidator->id);
+
         $this->assertFalse(Gate::forUser($validator)->allows('update', $ecPoi));
     }
 


### PR DESCRIPTION
## Summary
- Abilita i Validator (gestori di cammino) a creare e modificare i propri EcPoi, restando in sola lettura sul delete (esclusivo Administrator)
- `EcPoiPolicy`: create/update scoping su layer/user_id proprio
- `App\Nova\EcPoi`: authorizedToCreate/Update coerenti con la policy, campo layer in creazione (Select con validazione server-side per Validator con più layer)
- `EcPoiValidatorLayerObserver`: attach automatico del nuovo EcPoi al layer del Validator via pivot `layerables`
- Richiede wm-package @ 60f88f45 (fix rollback transazione in `GeometryComputationService::geometryModelToBbox`, altrimenti la creazione EcPoi fallisce con 500 per transazione Postgres avvelenata)

## Test plan
- [x] `EcPoiPolicyTest` (15 test)
- [x] `EcPoiNovaAuthorizationTest` (5 test)
- [x] `EcPoiLayerAssignmentTest` (3 test)
- [x] Nessuna regressione su `LayerActionsVisibilityTest`, `LayerServiceUpdateLayersPropertyGuardTest`

Ticket: oc:8304

🤖 Generated with [Claude Code](https://claude.com/claude-code)