### PR TITLE
fix(oc:8311): filtro ownership su proprietario del layer per POI/tracce non proprie

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,10 @@ La relazione user → layer è `$user->layers()` (`HasMany` via `user_id` su tab
 
 ## Decisioni architetturali
 
+### Visibilità POI/tracce non proprie nel pannello manuale di Layer (oc:8311)
+- La regola "ognuno vede/gestisce sempre e solo il proprio contenuto" (`user_id`) si applica a **tutti i ruoli senza eccezioni**, Administrator incluso — l'ownership su un layer riflette sempre il gestore attuale perché il trasferimento al cambio owner è già gestito da `LayerObserver` (oc:8080); l'Administrator può avere più EC solo perché è l'unico che può possedere più layer contemporaneamente (bootstrap iniziale)
+- La modalità `auto` di `sync()` (`LayerFeatureController`) non usa più `assignTracksByTaxonomy`/`assignPoisByTaxonomy` del package (logica a tassonomia): per camminiditalia `auto=true` significa "assegna al layer tutti gli EC di cui sono proprietario", senza tassonomia né filtro `app_id` (il progetto ha una sola app)
+
 ### Colonna layer linkabile e filtro layer su UgcPoi/UgcTrack (oc:8276)
 - Logica di risoluzione layer_id → nome/link e filtro Select estratta in `App\Nova\Traits\HasLayerFilterAndLink`, condiviso da `UgcPoi` e `UgcTrack` — evita la duplicazione del blocco Select introdotta da oc:7640 su UgcPoi soltanto
 - `layer_id` da `properties` va sempre validato con `is_numeric()` prima dell'uso: il filtro Select preesistente (oc:7640) usa un cast SQL `::integer` senza validazione, fragile su dati corrotti — rischio noto, non modificato in questo ciclo (fuori scope), ma il nuovo trait adotta validazione PHP-side per non ripeterlo

--- a/app/Http/Controllers/LayerFeatureController.php
+++ b/app/Http/Controllers/LayerFeatureController.php
@@ -2,11 +2,15 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\EcPoi;
+use App\Models\EcTrack;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Wm\WmPackage\Models\Layer;
 use Wm\WmPackage\Models\User;
@@ -42,9 +46,9 @@ class LayerFeatureController extends WmLayerFeatureController
             $viewMode = $validatedData['view_mode'] ?? 'edit';
 
             if (! in_array($validatedData['model'], [
-                \App\Models\EcPoi::class,
+                EcPoi::class,
                 \Wm\WmPackage\Models\EcPoi::class,
-                \App\Models\EcTrack::class,
+                EcTrack::class,
                 \Wm\WmPackage\Models\EcTrack::class,
             ], true)) {
                 return response()->json([
@@ -139,7 +143,7 @@ class LayerFeatureController extends WmLayerFeatureController
             ]);
         } catch (HttpExceptionInterface $e) {
             throw $e;
-        } catch (\Illuminate\Validation\ValidationException|\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+        } catch (ValidationException|ModelNotFoundException $e) {
             throw $e;
         } catch (\Exception $e) {
             Log::error('LayerFeatureController::getFeatures error', [
@@ -159,7 +163,7 @@ class LayerFeatureController extends WmLayerFeatureController
             $layer = Layer::findOrFail($layerId);
             $layerOwnerId = $layer->user_id ?? config('camminiditalia.default_owner_id');
 
-            /** @var \Wm\WmPackage\Models\User|null $user */
+            /** @var User|null $user */
             $user = Auth::user();
 
             if (! $user || ($layer->user_id !== $user->id && ! $user->hasRole('Administrator'))) {
@@ -173,9 +177,9 @@ class LayerFeatureController extends WmLayerFeatureController
             ]);
 
             if (! in_array($validatedData['model'], [
-                \App\Models\EcPoi::class,
+                EcPoi::class,
                 \Wm\WmPackage\Models\EcPoi::class,
-                \App\Models\EcTrack::class,
+                EcTrack::class,
                 \Wm\WmPackage\Models\EcTrack::class,
             ], true)) {
                 return response()->json([
@@ -226,7 +230,7 @@ class LayerFeatureController extends WmLayerFeatureController
             ], 200);
         } catch (HttpExceptionInterface $e) {
             throw $e;
-        } catch (\Illuminate\Validation\ValidationException|\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+        } catch (ValidationException|ModelNotFoundException $e) {
             throw $e;
         } catch (\Exception $e) {
             Log::error('LayerFeatureController::sync error', [

--- a/app/Http/Controllers/LayerFeatureController.php
+++ b/app/Http/Controllers/LayerFeatureController.php
@@ -7,9 +7,11 @@ use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Wm\WmPackage\Models\Layer;
 use Wm\WmPackage\Models\User;
 use Wm\WmPackage\Nova\Fields\LayerFeatures\Http\Controllers\LayerFeatureController as WmLayerFeatureController;
+use Wm\WmPackage\Services\PBFGeneratorService;
 
 class LayerFeatureController extends WmLayerFeatureController
 {
@@ -17,6 +19,14 @@ class LayerFeatureController extends WmLayerFeatureController
     {
         try {
             $layer = Layer::findOrFail($layerId);
+            $layerOwnerId = $layer->user_id ?? config('camminiditalia.default_owner_id');
+
+            /** @var User|null $user */
+            $user = Auth::user();
+
+            if (! $user || ($layer->user_id !== $user->id && ! $user->hasRole('Administrator'))) {
+                abort(403);
+            }
 
             $validatedData = $request->validate([
                 'model' => 'required|string',
@@ -31,6 +41,17 @@ class LayerFeatureController extends WmLayerFeatureController
             $search = $validatedData['search'] ?? '';
             $viewMode = $validatedData['view_mode'] ?? 'edit';
 
+            if (! in_array($validatedData['model'], [
+                \App\Models\EcPoi::class,
+                \Wm\WmPackage\Models\EcPoi::class,
+                \App\Models\EcTrack::class,
+                \Wm\WmPackage\Models\EcTrack::class,
+            ], true)) {
+                return response()->json([
+                    'error' => "Modello '{$validatedData['model']}' non consentito.",
+                ], 400);
+            }
+
             // Creo un'istanza del modello per ottenere il nome della relazione
             $model = new $validatedData['model'];
 
@@ -40,16 +61,14 @@ class LayerFeatureController extends WmLayerFeatureController
                 ], 400);
             }
 
-            // Ottieni l'utente loggato
-            /** @var User|null $user */
-            $user = Auth::user();
-
             // Funzione helper per caricare le features associate
-            $getAssociatedFeatures = function () use ($model, $layerId, $search) {
+            $getAssociatedFeatures = function () use ($model, $layerId, $search, $layerOwnerId) {
                 $query = $model->newQuery();
                 $query->whereHas('associatedLayers', function ($q) use ($layerId) {
                     $q->where('layer_id', $layerId);
                 });
+
+                $query->where('user_id', $layerOwnerId);
 
                 if ($search) {
                     $query->where('name', 'like', "%{$search}%");
@@ -75,10 +94,8 @@ class LayerFeatureController extends WmLayerFeatureController
                     $otherQuery->where('app_id', $layer->app_id);
                 }
 
-                // Filtra per utente loggato (escludi Administrator)
-                if ($user && ! $user->hasRole('Administrator')) {
-                    $otherQuery->where('user_id', $user->id);
-                }
+                // Filtra per proprietario del layer (nessuna eccezione di ruolo)
+                $otherQuery->where('user_id', $layerOwnerId);
 
                 // Escludi quelle già associate
                 if ($associatedFeatures->isNotEmpty()) {
@@ -120,8 +137,99 @@ class LayerFeatureController extends WmLayerFeatureController
                     'total' => $features->total(),
                 ],
             ]);
+        } catch (HttpExceptionInterface $e) {
+            throw $e;
+        } catch (\Illuminate\Validation\ValidationException|\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            throw $e;
         } catch (\Exception $e) {
             Log::error('LayerFeatureController::getFeatures error', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'error' => 'Errore interno del server: '.$e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function sync(Request $request, $layerId): JsonResponse
+    {
+        try {
+            $layer = Layer::findOrFail($layerId);
+            $layerOwnerId = $layer->user_id ?? config('camminiditalia.default_owner_id');
+
+            /** @var \Wm\WmPackage\Models\User|null $user */
+            $user = Auth::user();
+
+            if (! $user || ($layer->user_id !== $user->id && ! $user->hasRole('Administrator'))) {
+                abort(403);
+            }
+
+            $validatedData = $request->validate([
+                'features' => 'array',
+                'model' => 'required|string',
+                'auto' => 'boolean',
+            ]);
+
+            if (! in_array($validatedData['model'], [
+                \App\Models\EcPoi::class,
+                \Wm\WmPackage\Models\EcPoi::class,
+                \App\Models\EcTrack::class,
+                \Wm\WmPackage\Models\EcTrack::class,
+            ], true)) {
+                return response()->json([
+                    'error' => "Modello '{$validatedData['model']}' non consentito.",
+                ], 400);
+            }
+
+            $model = new $validatedData['model'];
+
+            if (! method_exists($model, 'getLayerRelationName')) {
+                return response()->json([
+                    'error' => "Il modello '{$validatedData['model']}' non implementa l'interfaccia LayerRelatedModel.",
+                ], 400);
+            }
+
+            $relationName = $model->getLayerRelationName();
+
+            if (! method_exists($layer, $relationName)) {
+                return response()->json([
+                    'error' => "La relazione '{$relationName}' non esiste nel modello Layer.",
+                ], 400);
+            }
+
+            $isAutoRequest = ! empty($validatedData['auto']) && in_array($relationName, ['ecTracks', 'ecPois']);
+
+            if ($isAutoRequest) {
+                $ownedIds = $model->newQuery()->where('user_id', $layerOwnerId)->pluck('id')->toArray();
+
+                $layer->{$relationName}()->sync($ownedIds);
+            } else {
+                $requestedIds = $validatedData['features'] ?? [];
+
+                $ownedIds = $model->newQuery()->whereIn('id', $requestedIds)->where('user_id', $layerOwnerId)->pluck('id')->toArray();
+
+                $layer->{$relationName}()->sync($ownedIds);
+            }
+
+            if ($relationName === 'ecTracks') {
+                app(PBFGeneratorService::class)->regeneratePbfsForLayer($layer);
+            }
+
+            $tableName = $model->getTable();
+            $assignedIds = $layer->{$relationName}()->select($tableName.'.id')->pluck('id')->toArray();
+
+            return response()->json([
+                'message' => 'Features sincronizzate con successo',
+                'assigned_ids' => $assignedIds,
+            ], 200);
+        } catch (HttpExceptionInterface $e) {
+            throw $e;
+        } catch (\Illuminate\Validation\ValidationException|\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            Log::error('LayerFeatureController::sync error', [
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
             ]);

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -44,13 +44,14 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
             Nova::script('config-home-sorter', resource_path('js/nova/config-home-sorter.js'));
         });
 
-        // Questa route sovrascrive quella del wm-package permettendo
-        // di filtrare le tracce per utente loggato senza modificare il package.
-        // Le altre route (index e sync) vengono ereditate dal package.
+        // Queste route sovrascrivono quelle del wm-package permettendo
+        // di filtrare per utente loggato senza modificare il package.
+        // L'unica route ereditata invariata dal package è "index".
         Route::middleware(['nova'])
             ->prefix('nova-vendor/layer-features')
             ->group(function () {
                 Route::get('/features/{layerId}', [LayerFeatureController::class, 'getFeatures']);
+                Route::post('/sync/{layerId}', [LayerFeatureController::class, 'sync']);
             });
 
         $this->getFooter();

--- a/docs/features/8311-visibilita-poi-tracce-non-proprie-pannello-manuale-layer/notes.md
+++ b/docs/features/8311-visibilita-poi-tracce-non-proprie-pannello-manuale-layer/notes.md
@@ -1,0 +1,26 @@
+> Ticket: oc:8311
+
+# Notes — Visibilità POI/tracce non proprie nel pannello manuale di Layer
+
+## Deviazioni dal piano
+
+- Il piano originale (Task 1-4) prevedeva il filtro ownership basato su `Auth::user()->id` (utente loggato), senza eccezioni di ruolo. Dopo l'esecuzione, un test manuale in ambiente locale (layer 130) ha mostrato che questo approccio rompeva l'operatività reale degli account Administrator (che spesso non possiedono EC propri, gestendo contenuti creati da Validator). Corretto in Task 5: il filtro è ora basato su `$layer->user_id` (proprietario del layer). Vedi `plan.md`, Task 5, per il dettaglio completo.
+- Nei test, il piano suggeriva `$layer->ecPois()->attach($poiId)` per simulare "un EC di un altro owner già associato al layer". Questo si è rivelato inutilizzabile: `App\Observers\LayerableObserver::created()` (oc:8080/oc:8139) riassegna silenziosamente `user_id` del POI al proprietario del layer non appena viene chiamato `attach()` (la relazione usa un pivot custom `Layerable`, quindi l'attach scatena eventi Eloquent). Sostituito con inserimento diretto in `layerables` via `DB::table()->insert()`, bypassando l'observer — pattern già in uso altrove nel repo per lo stesso motivo.
+
+## Bug trovati
+
+- Nessun bug pre-esistente introdotto da questo lavoro. Un comportamento pre-esistente nel wm-package è stato scoperto durante il Task 4: `regeneratePbfsForLayer` viene chiamato due volte per un singolo sync di `ecTracks` (una volta esplicitamente dal controller, una volta implicitamente da `LayerableObserver::created()`). Non introdotto da oc:8311, verificato confrontando col comportamento del `sync()` ereditato dal package — stessa duplicazione già presente prima del fix. Segnalato come follow-up, non corretto in questo ciclo.
+
+## Decisioni
+
+- Filtro ownership basato sul **proprietario del layer** (`$layer->user_id`), non sull'utente che effettua la richiesta — vedi `plan.md` Task 5 e `overview.md` per la motivazione completa (un Administrator gestisce spesso contenuti non propri).
+- Aggiunto un controllo di autorizzazione 403 (solo proprietario del layer o Administrator possono operare su un dato `layerId`) e un'allowlist sul parametro `model` — non previsti nel piano originale, emersi dalla review finale del branch (finding Critical: l'allowlist iniziale rifiutava `Wm\WmPackage\Models\EcPoi`, la classe realmente inviata dal frontend Nova quando `wm-package.ec_poi_model` non è configurato — corretto per accettare entrambe le varianti).
+- **Layer orfano (`user_id` null):** emerso da `wm-skills:wm-review-ticket`, confermato con dati reali (55 layer e 321 EcTrack con `user_id` null nel DB di sviluppo) — `->where('user_id', $layer->user_id)` con valore `null` degenera in Eloquent in `whereNull('user_id')`, esponendo a un Administrator (unico ruolo che supera il 403 su un layer senza owner) tutti gli EC orfani del sistema, non solo quelli pertinenti al layer. Corretto risolvendo l'owner effettivo con fallback a `config('camminiditalia.default_owner_id')` (stesso meccanismo già usato in oc:8080 per il trasferimento ownership) quando `$layer->user_id` è null, usato ovunque al posto di `$layer->user_id` diretto nelle query di scoping.
+- Nessuna modifica al submodule `wm-package` in tutto il ciclo.
+
+## Follow-up
+
+- Doppia chiamata a `regeneratePbfsForLayer` per sync di `ecTracks` (vedi "Bug trovati" sopra) — comportamento preesistente nel wm-package, da valutare in un ticket separato.
+- L'override locale di `getFeatures()` resta strutturalmente più datato rispetto alla versione più recente nel package (che gestisce logica taxonomy/auto-mode in lettura, assente nell'override locale) — fuori scope confermato in `overview.md`, da considerare in un ciclo futuro se necessario allineare il display.
+- `wm-skills:wm-review-ticket` ha segnalato debito architetturale crescente (override locale completo ora su 2 metodi invece di 1, sempre più disallineato dal package) e diversi punti di duplicazione (blocco autorizzazione, allowlist, gestione errori ripetuti identici in `getFeatures()`/`sync()`) — non corretti in questo ciclo (cleanup non bloccante), candidati per un refactor futuro se si tocca ancora questo controller.
+- Test `test_administrator_sync_filters_out_ec_poi_not_owned` non copre esplicitamente lo scenario cross-owner (Administrator su layer di un Validator) per `sync()`, solo per `getFeatures()` — gap di copertura minore segnalato dalla review, non bloccante.

--- a/docs/features/8311-visibilita-poi-tracce-non-proprie-pannello-manuale-layer/overview.md
+++ b/docs/features/8311-visibilita-poi-tracce-non-proprie-pannello-manuale-layer/overview.md
@@ -1,0 +1,54 @@
+> Ticket: oc:8311
+
+# Visibilità POI/tracce non proprie nel pannello manuale di Layer
+
+## Cosa cambia
+
+`LayerFeatureController::getFeatures()` (repo principale, override locale del package) filtra per `user_id` anche la lista delle feature **già associate** al layer (`getAssociatedFeatures()`), non solo quella delle feature disponibili da aggiungere.
+
+**Il filtro `user_id` è sempre rispetto al proprietario del layer (`$layer->user_id`), non rispetto all'utente loggato.** Un Validator che apre il proprio layer coincide comunque con `$layer->user_id`, quindi per lui non cambia nulla nella pratica. Un Administrator che apre un layer di un Validator vede le feature del **proprietario di quel layer**, non le proprie — perché in produzione gli account Administrator usati per operazioni di gestione spesso non possiedono EC propri (gestiscono contenuti creati da Validator o importati): un filtro basato sull'utente loggato lascerebbe l'Administrator senza nulla da vedere/gestire, rompendo l'operatività reale. Questo sostituisce la formulazione iniziale ("nessuna eccezione di ruolo, filtro su `Auth::user()->id`"), corretta dopo verifica in ambiente locale (layer 130: il proprietario possiede 325 EcPoi, ma gli account Administrator usati per testare ne possiedono 0 ciascuno — il filtro sull'utente loggato mostrava 0 feature disponibili anche se ne esistevano 606 nel sistema).
+
+Viene inoltre creato un override locale di `sync()` (assente oggi: l'endpoint è ereditato tal quale dal package, senza alcun controllo di ownership) che filtra silenziosamente dalla richiesta gli ID di feature non appartenenti al **proprietario del layer** prima di eseguire la sincronizzazione.
+
+**Cambio di comportamento per la modalità `auto`:** oggi `auto=true` in `sync()` ricalcola l'associazione layer↔EC per corrispondenza di tassonomia (`assignTracksByTaxonomy`/`assignPoisByTaxonomy` nel package), ignorando del tutto ownership e `features[]` inviato. Questo bypassava il filtro previsto per il fix. La logica a tassonomia viene rimossa: `auto=true` assegna al layer tutti gli EC (poi/track) di cui il **proprietario del layer** è `user_id`, indipendentemente da chi effettua la chiamata — coerente con "il mio cammino contiene ciò che io creo" per il gestore proprietario. Non serve un filtro `app_id` aggiuntivo: il progetto ha un'unica app.
+
+## Perché
+
+Un Validator (gestore di cammino) che passa alla modalità manuale su Ec Pois/Ec Tracks di un proprio layer vede oggi anche POI/tracce già associate ma appartenenti ad altri gestori — violazione dello scoping per-utente già applicato altrove nel progetto (oc:7640, oc:8304). Lo stesso vale, potenzialmente in modo più grave, per `sync()`: un Validator potrebbe associare o rimuovere dal layer feature non proprie tramite chiamata diretta all'endpoint, senza passare dalla UI.
+
+## Requisiti
+
+- [ ] `getAssociatedFeatures()` in `App\Http\Controllers\LayerFeatureController::getFeatures()` filtra per `user_id` **del proprietario del layer** (`$layer->user_id`), indipendentemente da chi effettua la richiesta, applicandosi sia al ramo `view_mode=details` sia al ramo `view_mode=edit`
+- [ ] Nuovo override locale di `sync()` (route + controller) segue lo stesso pattern già documentato in CLAUDE.md per `getFeatures` ("sovrascrive quella del wm-package senza modificare il package")
+- [ ] `sync()` filtra silenziosamente dalla lista `features` inviata, mantenendo solo gli ID appartenenti al **proprietario del layer** (`$layer->user_id`), nessun errore, sync procede solo con quegli ID
+- [ ] `sync()` con `auto=true`: bypassa `assignTracksByTaxonomy`/`assignPoisByTaxonomy` del package, assegna al layer tutti gli EC (poi/track) di cui il **proprietario del layer** è `user_id`, senza filtro di tassonomia né `app_id`
+- [ ] `sync()` continua a richiamare esplicitamente `PBFGeneratorService::regeneratePbfsForLayer()` per `ecTracks` dopo il sync/auto-assign (side-effect del parent nel package, da non perdere nell'override locale)
+- [ ] Solo il proprietario del layer o un Administrator possono chiamare `getFeatures()`/`sync()` per un dato `layerId` (403 altrimenti) — un Validator non può forzare una sync/lettura su un layer che non possiede, anche se l'esito userebbe comunque gli EC del vero proprietario
+- [ ] `$validatedData['model']` è validato con un'allowlist esplicita (`EcPoi::class`, `EcTrack::class`) prima dell'istanziazione, non solo verificato a posteriori con `method_exists`
+- [ ] Suite di test Feature per `LayerFeatureController`: Validator A non vede/non sincronizza EC di Validator B; Administrator che apre un layer di un Validator vede/gestisce gli EC del **proprietario del layer**, non i propri; `auto=true` assegna al layer solo gli EC del proprietario del layer, ignorando la tassonomia; rigenerazione PBF invocata su sync di `ecTracks`; un utente che non possiede il layer riceve 403 su `getFeatures`/`sync`; un `model` non in allowlist viene rifiutato; copertura sia `getFeatures` (details+edit) sia `sync`
+
+**Nota (corretta dopo verifica in ambiente locale):** il filtro è sempre rispetto al proprietario del layer, non all'utente loggato — nessuna eccezione di ruolo necessaria perché il criterio non è più "chi sono io" ma "chi possiede questo layer". Questo evita che un Administrator senza EC propri (comune in produzione: gestisce contenuti creati da altri) veda 0 feature disponibili aprendo un layer altrui.
+
+## Rischi
+
+- L'override locale di `getFeatures` è una reimplementazione più datata rispetto alla versione attuale nel package (che gestisce già logica taxonomy/auto-mode assente nell'override locale). Questo ciclo **non** allinea l'override alla versione più recente del package — rischio noto, accettato, fuori scope (si valuta un ticket separato in futuro, come già fatto per oc:8312 con PHPStan)
+- Filtro silenzioso su `sync()`: se un client invia una lista mista di ID propri/altrui per un bug di UI, la richiesta non fallisce e il Validator potrebbe non accorgersi che alcuni ID sono stati ignorati — accettato per coerenza con il comportamento già adottato in `getFeatures`
+- Il modello passato a `sync()`/`getFeatures()` era generico (`$validatedData['model']`), istanziato prima di qualunque verifica — mitigato con l'allowlist esplicita (vedi Requisiti)
+- Un layer con EC storicamente auto-assegnati per tassonomia (comportamento precedente) vede il proprio pivot **ricalcolato per intero** non appena viene chiamato `auto=true`: l'override locale sostituisce l'associazione per quella relazione con "solo gli EC del proprietario del layer". Non è un problema nella pratica corrente perché l'ownership sul layer riflette sempre il gestore attuale (cascata via `LayerObserver`, oc:8080), ma resta un cambio di semantica netto rispetto al comportamento a tassonomia del package
+- Un layer il cui proprietario non possiede alcun EC svuota di fatto il pivot della relazione quando viene chiamato `auto=true` — comportamento coerente con la nuova semantica, ma potenzialmente sorprendente se il layer aveva contenuti auto-assegnati in precedenza
+- Senza il controllo di autorizzazione sul layer (vedi Requisiti), qualunque utente autenticato poteva forzare una `sync()`/lettura su un layer altrui: l'esito era comunque limitato agli EC del vero proprietario (nessun data leak), ma permetteva comunque un reset non autorizzato del pivot altrui in modalità manuale (l'utente chiamante poteva svuotare/sostituire l'associazione di un layer che non gli appartiene, anche se con contenuti "corretti") — richiesto un controllo esplicito di ownership sul layer
+- Verificato: `index()` (ereditato dal package, non toccato) restituisce solo un conteggio (`count`) delle feature associate al layer, non lista di ID/nomi — non espone lo stesso data leak di `getFeatures`/`sync`, nessun fix necessario
+- Nota operativa per il deploy: se in produzione è attivo `route:cache`, serve un `route:clear`/`route:cache` esplicito dopo il deploy perché la nuova route locale `sync/{layerId}` sostituisca effettivamente quella ereditata dal package (stesso rischio già presente oggi per l'override di `getFeatures`)
+
+## Out of scope
+
+- Allineamento dell'override locale di `getFeatures` alla logica taxonomy/auto-mode più recente del package (l'override locale continua a non implementare display auto-mode/taxonomy: resta lo split associate/available esistente)
+- Trasferimento ownership al cambio owner del layer (già gestito da `LayerObserver`, oc:8080)
+- Rimozione della logica a tassonomia per layer gestiti da Administrator (resta invariata)
+- Modifiche al wm-package (nessuna modifica generica al package in questo ciclo — il bypass della tassonomia per Validator è implementato interamente nell'override locale)
+
+## Moduli toccati
+
+- `app/Http/Controllers/LayerFeatureController.php` (repo principale) — fix filtro `user_id` su `getAssociatedFeatures()`; nuovo metodo `sync()`
+- `app/Providers/NovaServiceProvider.php` (repo principale) — registrazione route override per `sync/{layerId}`
+- `tests/Feature/LayerFeatureControllerTest.php` (repo principale, nuovo file) — test di regressione

--- a/docs/features/8311-visibilita-poi-tracce-non-proprie-pannello-manuale-layer/plan.md
+++ b/docs/features/8311-visibilita-poi-tracce-non-proprie-pannello-manuale-layer/plan.md
@@ -1,0 +1,578 @@
+> Ticket: oc:8311
+
+# Visibilità POI/tracce non proprie nel pannello manuale di Layer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Impedire che un utente veda o sincronizzi POI/tracce (EC) non proprie nel pannello Nova di gestione layer, sia in lettura (`getFeatures`) sia in scrittura (`sync`), e sostituire la modalità `auto` con un'assegnazione basata su ownership invece che su tassonomia.
+
+**Architecture:** Tutte le modifiche restano nell'override locale `App\Http\Controllers\LayerFeatureController` (estende `Wm\WmPackage\Nova\Fields\LayerFeatures\Http\Controllers\LayerFeatureController`), coerente col pattern già in uso per `getFeatures`. Nessuna modifica al submodule `wm-package`. Viene aggiunto un override locale di `sync()` con relativa route in `NovaServiceProvider`, che sovrascrive quella ereditata dal package.
+
+**Tech Stack:** Laravel 11 (PHP 8.4), Nova, PostGIS, PHPUnit (Feature test, `RefreshDatabase`/`DatabaseTransactions`), Spatie permissions (ruoli `Administrator`, `Validator`, `Guest`).
+
+> **⚠️ Correzione post-esecuzione (vedi Task 5):** i Task 1-4 sotto sono documentati come originariamente pianificati ed eseguiti, con il filtro ownership basato su **`Auth::user()->id`** (utente loggato). Durante il test manuale in ambiente locale (layer 130), questo approccio si è rivelato errato: un Administrator senza EC propri (comune in produzione — gestisce contenuti creati da Validator) vedeva 0 feature disponibili aprendo un layer altrui, pur esistendone centinaia nel sistema. Il Task 5 documenta la correzione: il filtro è ora basato su **`$layer->user_id`** (proprietario del layer), con l'aggiunta di un controllo di autorizzazione 403 e un'allowlist sul parametro `model`. Il codice attuale nel repo riflette il Task 5, non il codice originale mostrato nei Task 1-4 (mantenuto qui come registro storico del percorso seguito). Vedi anche `overview.md`, sezione "Cosa cambia", per la spiegazione completa.
+
+## Global Constraints
+
+- Nessuna eccezione di ruolo per il filtro `user_id`: si applica identicamente a `Administrator`, `Validator`, `Guest` — NON usare `hasRole('Administrator')` per bypassare i filtri introdotti in questo piano.
+- Nessuna modifica al submodule `wm-package` in nessun task.
+- Nessun filtro `app_id` da introdurre (il progetto ha una sola app).
+- Tutti i comandi `php artisan`/test vanno eseguiti dentro il container: `docker exec laravel-camminiditalia php artisan test --filter=NomeTest`.
+- Commit convention: `fix(oc:8311): ...`. I passi "Commit" del piano sono istruzioni testuali per l'utente — nessun commit va eseguito autonomamente durante l'implementazione.
+
+---
+
+## File Structure
+
+- **Modifica:** `app/Http/Controllers/LayerFeatureController.php` — aggiunge il filtro `user_id` a `getFeatures()` (Task 1) e introduce un nuovo metodo `sync()` (Task 2 e 3).
+- **Modifica:** `app/Providers/NovaServiceProvider.php` — registra la route `POST /nova-vendor/layer-features/sync/{layerId}` che sovrascrive quella ereditata dal package (Task 2).
+- **Nuovo:** `tests/Feature/LayerFeatureControllerTest.php` — suite di test di regressione per `getFeatures` e `sync` (un metodo di test per step, aggiunto progressivamente nei Task 1-3).
+
+---
+
+### Task 1: Filtro `user_id` su `getFeatures()` (lettura, nessuna eccezione di ruolo)
+
+**Files:**
+- Modify: `app/Http/Controllers/LayerFeatureController.php:44-86`
+- Test: `tests/Feature/LayerFeatureControllerTest.php` (nuovo file)
+
+**Interfaces:**
+- Consumes: `Wm\WmPackage\Models\Layer::ecPois()`/`ecTracks()` (morphedByMany esistenti), `App\Models\EcPoi`/`App\Models\EcTrack` con colonna `user_id` (nullable), relazione `associatedLayers()` su EC (da `Wm\WmPackage\Traits\EcFeatureTrait`).
+- Produces: nessuna interfaccia nuova consumata da altri task — Task 2/3 toccano `sync()`, un metodo separato nello stesso file.
+
+- [x] **Step 1: Scrivi il test che riproduce il bug (fallisce oggi)**
+
+Crea `tests/Feature/LayerFeatureControllerTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\EcPoi;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Services\RolesAndPermissionsService;
+
+class LayerFeatureControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        RolesAndPermissionsService::seedDatabase();
+        if (App::count() === 0) {
+            App::factory()->create();
+        }
+    }
+
+    private function makeUser(string $role): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole($role);
+
+        return $user;
+    }
+
+    private function makePoi(?int $userId): EcPoi
+    {
+        return EcPoi::factory()->create(['user_id' => $userId, 'properties' => []]);
+    }
+
+    public function test_validator_does_not_see_ec_poi_of_another_validator_in_associated_features_edit_mode(): void
+    {
+        $validatorA = $this->makeUser('Validator');
+        $validatorB = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validatorA->id]);
+
+        $poiOfB = $this->makePoi($validatorB->id);
+        $layer->ecPois()->attach($poiOfB->id);
+
+        $response = $this->actingAs($validatorA)
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(EcPoi::class).'&view_mode=edit&manual=1');
+
+        $response->assertOk();
+        $ids = collect($response->json('features'))->pluck('id')->toArray();
+        $this->assertNotContains($poiOfB->id, $ids);
+    }
+
+    public function test_validator_does_not_see_ec_poi_of_another_validator_in_details_mode(): void
+    {
+        $validatorA = $this->makeUser('Validator');
+        $validatorB = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validatorA->id]);
+
+        $poiOfB = $this->makePoi($validatorB->id);
+        $layer->ecPois()->attach($poiOfB->id);
+
+        $response = $this->actingAs($validatorA)
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(EcPoi::class).'&view_mode=details&manual=1');
+
+        $response->assertOk();
+        $ids = collect($response->json('features'))->pluck('id')->toArray();
+        $this->assertNotContains($poiOfB->id, $ids);
+    }
+
+    public function test_administrator_does_not_see_ec_poi_not_owned_in_associated_features(): void
+    {
+        $admin = $this->makeUser('Administrator');
+        $otherOwner = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $admin->id]);
+
+        $poiOfOther = $this->makePoi($otherOwner->id);
+        $layer->ecPois()->attach($poiOfOther->id);
+
+        $response = $this->actingAs($admin)
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(EcPoi::class).'&view_mode=edit&manual=1');
+
+        $response->assertOk();
+        $ids = collect($response->json('features'))->pluck('id')->toArray();
+        $this->assertNotContains($poiOfOther->id, $ids);
+    }
+
+    public function test_validator_sees_own_ec_poi_in_associated_features(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $ownPoi = $this->makePoi($validator->id);
+        $layer->ecPois()->attach($ownPoi->id);
+
+        $response = $this->actingAs($validator)
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(EcPoi::class).'&view_mode=edit&manual=1');
+
+        $response->assertOk();
+        $ids = collect($response->json('features'))->pluck('id')->toArray();
+        $this->assertContains($ownPoi->id, $ids);
+    }
+}
+```
+
+- [x] **Step 2: Esegui i test e verifica che i primi tre falliscano**
+
+Run: `docker exec laravel-camminiditalia php artisan test --filter=LayerFeatureControllerTest`
+Expected: `test_validator_does_not_see_ec_poi_of_another_validator_in_associated_features_edit_mode` FALLISCE (il POI di B è ancora incluso), `test_validator_does_not_see_ec_poi_of_another_validator_in_details_mode` FALLISCE, `test_administrator_does_not_see_ec_poi_not_owned_in_associated_features` FALLISCE, `test_validator_sees_own_ec_poi_in_associated_features` PASSA già.
+
+- [x] **Step 3: Applica il filtro `user_id` a `getAssociatedFeatures()` e alla lista "altre disponibili", senza eccezione di ruolo**
+
+In `app/Http/Controllers/LayerFeatureController.php`, sostituisci il blocco della closure `$getAssociatedFeatures` (righe 48-59):
+
+```php
+            // Funzione helper per caricare le features associate
+            $getAssociatedFeatures = function () use ($model, $layerId, $search, $user) {
+                $query = $model->newQuery();
+                $query->whereHas('associatedLayers', function ($q) use ($layerId) {
+                    $q->where('layer_id', $layerId);
+                });
+
+                if ($user) {
+                    $query->where('user_id', $user->id);
+                }
+
+                if ($search) {
+                    $query->where('name', 'like', "%{$search}%");
+                }
+
+                return $query->select(['id', 'name'])->orderBy('name', 'ASC');
+            };
+```
+
+E sostituisci il blocco del filtro sulla lista "altre disponibili" (righe 78-81), rimuovendo l'eccezione per Administrator:
+
+```php
+                // Filtra per utente loggato (nessuna eccezione di ruolo)
+                if ($user) {
+                    $otherQuery->where('user_id', $user->id);
+                }
+```
+
+- [x] **Step 4: Esegui di nuovo i test e verifica che passino tutti**
+
+Run: `docker exec laravel-camminiditalia php artisan test --filter=LayerFeatureControllerTest`
+Expected: PASS su tutti e 4 i test.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add app/Http/Controllers/LayerFeatureController.php tests/Feature/LayerFeatureControllerTest.php
+git commit -m "fix(oc:8311): filtra per user_id le feature associate al layer senza eccezione di ruolo"
+```
+
+---
+
+### Task 2: Override locale di `sync()` — filtro ownership sugli ID inviati (modalità manuale)
+
+**Files:**
+- Modify: `app/Http/Controllers/LayerFeatureController.php` (aggiunge nuovo metodo `sync()` in coda alla classe)
+- Modify: `app/Providers/NovaServiceProvider.php:47-54`
+- Test: `tests/Feature/LayerFeatureControllerTest.php` (aggiunge metodi di test)
+
+**Interfaces:**
+- Consumes: `Wm\WmPackage\Models\Layer::findOrFail()`, `$layer->{$relationName}()` (`MorphToMany` da `ecTracks()`/`ecPois()`), `$model->getLayerRelationName(): string`, `Wm\WmPackage\Services\PBFGeneratorService::regeneratePbfsForLayer(Layer $layer): void` (già iniettabile via constructor injection Laravel).
+- Produces: `App\Http\Controllers\LayerFeatureController::sync(Request $request, $layerId): JsonResponse` — firma identica al parent, risposta JSON `{message, assigned_ids}` come oggi. Task 3 estende questo stesso metodo per il ramo `auto=true`.
+
+- [x] **Step 1: Scrivi il test che riproduce il bug (fallisce oggi — la route esistente non filtra per ownership)**
+
+Aggiungi in `tests/Feature/LayerFeatureControllerTest.php`:
+
+```php
+    public function test_validator_sync_filters_out_ec_poi_not_owned(): void
+    {
+        $validatorA = $this->makeUser('Validator');
+        $validatorB = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validatorA->id]);
+
+        $ownPoi = $this->makePoi($validatorA->id);
+        $poiOfB = $this->makePoi($validatorB->id);
+
+        $response = $this->actingAs($validatorA)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcPoi::class,
+                'features' => [$ownPoi->id, $poiOfB->id],
+            ]);
+
+        $response->assertOk();
+        $assignedIds = $response->json('assigned_ids');
+        $this->assertContains($ownPoi->id, $assignedIds);
+        $this->assertNotContains($poiOfB->id, $assignedIds);
+        $this->assertTrue($layer->ecPois()->where('ec_pois.id', $ownPoi->id)->exists());
+        $this->assertFalse($layer->ecPois()->where('ec_pois.id', $poiOfB->id)->exists());
+    }
+
+    public function test_administrator_sync_filters_out_ec_poi_not_owned(): void
+    {
+        $admin = $this->makeUser('Administrator');
+        $otherOwner = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $admin->id]);
+
+        $ownPoi = $this->makePoi($admin->id);
+        $poiOfOther = $this->makePoi($otherOwner->id);
+
+        $response = $this->actingAs($admin)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcPoi::class,
+                'features' => [$ownPoi->id, $poiOfOther->id],
+            ]);
+
+        $response->assertOk();
+        $assignedIds = $response->json('assigned_ids');
+        $this->assertContains($ownPoi->id, $assignedIds);
+        $this->assertNotContains($poiOfOther->id, $assignedIds);
+    }
+```
+
+- [x] **Step 2: Esegui i test e verifica che falliscano**
+
+Run: `docker exec laravel-camminiditalia php artisan test --filter=LayerFeatureControllerTest`
+Expected: FALLISCONO entrambi i nuovi test (`sync` ereditato dal package associa anche `$poiOfB`/`$poiOfOther` perché non applica alcun filtro `user_id`).
+
+- [x] **Step 3: Implementa `sync()` locale con filtro ownership (ramo non-auto) e mantieni la rigenerazione PBF**
+
+Aggiungi in coda a `app/Http/Controllers/LayerFeatureController.php` (prima della chiusura `}` della classe), gli import necessari in testa al file, e il nuovo metodo:
+
+`Auth` e `Log` sono già importati in cima al file (non duplicarli). Aggiungi solo:
+
+```php
+use Wm\WmPackage\Services\PBFGeneratorService;
+```
+
+(`LayerService` NON va importato: il nuovo `sync()` non richiama più `assignTracksByTaxonomy`/`assignPoisByTaxonomy`, quindi non serve.)
+
+Aggiungi il metodo `sync()`:
+
+```php
+    public function sync(Request $request, $layerId): JsonResponse
+    {
+        try {
+            $layer = Layer::findOrFail($layerId);
+
+            $validatedData = $request->validate([
+                'features' => 'array',
+                'model' => 'required|string',
+                'auto' => 'boolean',
+            ]);
+
+            $model = new $validatedData['model'];
+
+            if (! method_exists($model, 'getLayerRelationName')) {
+                return response()->json([
+                    'error' => "Il modello '{$validatedData['model']}' non implementa l'interfaccia LayerRelatedModel.",
+                ], 400);
+            }
+
+            $relationName = $model->getLayerRelationName();
+
+            if (! method_exists($layer, $relationName)) {
+                return response()->json([
+                    'error' => "La relazione '{$relationName}' non esiste nel modello Layer.",
+                ], 400);
+            }
+
+            /** @var \Wm\WmPackage\Models\User|null $user */
+            $user = Auth::user();
+
+            $isAutoRequest = ! empty($validatedData['auto']) && in_array($relationName, ['ecTracks', 'ecPois']);
+
+            if ($isAutoRequest) {
+                $ownedIds = $user
+                    ? $model->newQuery()->where('user_id', $user->id)->pluck('id')->toArray()
+                    : [];
+
+                $layer->{$relationName}()->sync($ownedIds);
+            } else {
+                $requestedIds = $validatedData['features'] ?? [];
+
+                $ownedIds = $user
+                    ? $model->newQuery()->whereIn('id', $requestedIds)->where('user_id', $user->id)->pluck('id')->toArray()
+                    : [];
+
+                $layer->{$relationName}()->sync($ownedIds);
+            }
+
+            if ($relationName === 'ecTracks') {
+                app(PBFGeneratorService::class)->regeneratePbfsForLayer($layer);
+            }
+
+            $tableName = $model->getTable();
+            $assignedIds = $layer->{$relationName}()->select($tableName.'.id')->pluck('id')->toArray();
+
+            return response()->json([
+                'message' => 'Features sincronizzate con successo',
+                'assigned_ids' => $assignedIds,
+            ], 200);
+        } catch (\Exception $e) {
+            Log::error('LayerFeatureController::sync error', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'error' => 'Errore interno del server: '.$e->getMessage(),
+            ], 500);
+        }
+    }
+```
+
+Nota: il ramo `$isAutoRequest` qui sopra è già scritto per il comportamento finale del Task 3 (ownership invece di tassonomia) — non richiama `LayerService::assignTracksByTaxonomy`/`assignPoisByTaxonomy`. Il test del ramo auto viene aggiunto e verificato in Task 3; in questo step verifica solo che il ramo non-auto passi.
+
+- [x] **Step 4: Registra la route locale che sovrascrive `sync` del package**
+
+In `app/Providers/NovaServiceProvider.php`, modifica il blocco (righe 47-54):
+
+```php
+        // Queste route sovrascrivono quelle del wm-package permettendo
+        // di filtrare per utente loggato senza modificare il package.
+        // L'unica route ereditata invariata dal package è "index".
+        Route::middleware(['nova'])
+            ->prefix('nova-vendor/layer-features')
+            ->group(function () {
+                Route::get('/features/{layerId}', [LayerFeatureController::class, 'getFeatures']);
+                Route::post('/sync/{layerId}', [LayerFeatureController::class, 'sync']);
+            });
+```
+
+- [x] **Step 5: Esegui i test e verifica che passino**
+
+Run: `docker exec laravel-camminiditalia php artisan test --filter=LayerFeatureControllerTest`
+Expected: PASS su tutti i test (6 totali finora).
+
+- [x] **Step 6: Commit**
+
+```bash
+git add app/Http/Controllers/LayerFeatureController.php app/Providers/NovaServiceProvider.php tests/Feature/LayerFeatureControllerTest.php
+git commit -m "fix(oc:8311): override locale di sync() con filtro ownership sugli ID inviati"
+```
+
+---
+
+### Task 3: Modalità `auto` basata su ownership invece che su tassonomia
+
+**Files:**
+- Modify: nessuna modifica di codice aggiuntiva (il ramo `$isAutoRequest` è già implementato nel Task 2, Step 3) — solo test.
+- Test: `tests/Feature/LayerFeatureControllerTest.php` (aggiunge metodi di test)
+
+**Interfaces:**
+- Consumes: `sync()` da Task 2 (nessuna interfaccia nuova).
+- Produces: nessuna interfaccia nuova per altri task.
+
+- [x] **Step 1: Scrivi il test per la modalità `auto`**
+
+Aggiungi in `tests/Feature/LayerFeatureControllerTest.php`:
+
+```php
+    public function test_sync_auto_true_assigns_only_owned_ec_pois_ignoring_taxonomy(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $otherValidator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $ownPoiA = $this->makePoi($validator->id);
+        $ownPoiB = $this->makePoi($validator->id);
+        $poiOfOther = $this->makePoi($otherValidator->id);
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcPoi::class,
+                'auto' => true,
+            ]);
+
+        $response->assertOk();
+        $assignedIds = $response->json('assigned_ids');
+        $this->assertContains($ownPoiA->id, $assignedIds);
+        $this->assertContains($ownPoiB->id, $assignedIds);
+        $this->assertNotContains($poiOfOther->id, $assignedIds);
+    }
+
+    public function test_sync_auto_true_replaces_pivot_with_only_callers_ec_pois(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $otherValidator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $poiOfOtherPreAssigned = $this->makePoi($otherValidator->id);
+        $layer->ecPois()->attach($poiOfOtherPreAssigned->id);
+
+        $ownPoi = $this->makePoi($validator->id);
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcPoi::class,
+                'auto' => true,
+            ]);
+
+        $response->assertOk();
+        $assignedIds = $response->json('assigned_ids');
+        $this->assertContains($ownPoi->id, $assignedIds);
+        $this->assertNotContains($poiOfOtherPreAssigned->id, $assignedIds);
+    }
+```
+
+- [x] **Step 2: Esegui i test**
+
+Run: `docker exec laravel-camminiditalia php artisan test --filter=LayerFeatureControllerTest`
+Expected: PASS su entrambi (il codice del Task 2 già implementa questo comportamento) — se falliscono, rileggi il ramo `$isAutoRequest` in `sync()` (Task 2, Step 3) e correggi prima di proseguire.
+
+- [x] **Step 3: Commit**
+
+```bash
+git add tests/Feature/LayerFeatureControllerTest.php
+git commit -m "test(oc:8311): copertura modalità auto basata su ownership"
+```
+
+---
+
+### Task 4: Verifica rigenerazione PBF su sync di `ecTracks`
+
+**Files:**
+- Test: `tests/Feature/LayerFeatureControllerTest.php` (aggiunge un metodo di test)
+
+**Interfaces:**
+- Consumes: `sync()` da Task 2/3, `Wm\WmPackage\Services\PBFGeneratorService::regeneratePbfsForLayer(Layer $layer): void`.
+- Produces: nessuna interfaccia nuova.
+
+- [x] **Step 1: Verifica come sono strutturati EcTrack e la sua factory**
+
+Run: `docker exec laravel-camminiditalia php artisan tinker --execute="echo (new \App\Models\EcTrack())->getLayerRelationName();"`
+Expected: output `ecTracks`.
+
+- [x] **Step 2: Scrivi il test con mock del servizio PBF**
+
+Aggiungi in `tests/Feature/LayerFeatureControllerTest.php` (aggiungi l'import `use App\Models\EcTrack;` e `use Wm\WmPackage\Services\PBFGeneratorService;` in testa al file):
+
+```php
+    public function test_sync_ec_tracks_triggers_pbf_regeneration(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+        $ownTrack = EcTrack::factory()->create(['user_id' => $validator->id, 'properties' => []]);
+
+        $pbfMock = \Mockery::mock(PBFGeneratorService::class);
+        $pbfMock->shouldReceive('regeneratePbfsForLayer')
+            ->once()
+            ->withArgs(fn (Layer $l) => $l->id === $layer->id);
+        $this->app->instance(PBFGeneratorService::class, $pbfMock);
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcTrack::class,
+                'features' => [$ownTrack->id],
+            ]);
+
+        $response->assertOk();
+    }
+
+    public function test_sync_ec_pois_does_not_trigger_pbf_regeneration(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+        $ownPoi = $this->makePoi($validator->id);
+
+        $pbfMock = \Mockery::mock(PBFGeneratorService::class);
+        $pbfMock->shouldNotReceive('regeneratePbfsForLayer');
+        $this->app->instance(PBFGeneratorService::class, $pbfMock);
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcPoi::class,
+                'features' => [$ownPoi->id],
+            ]);
+
+        $response->assertOk();
+    }
+```
+
+- [x] **Step 3: Esegui i test**
+
+Run: `docker exec laravel-camminiditalia php artisan test --filter=LayerFeatureControllerTest`
+Expected: PASS su entrambi.
+
+- [x] **Step 4: Esegui l'intera suite per verificare nessuna regressione**
+
+Run: `docker exec laravel-camminiditalia php artisan test`
+Expected: PASS su tutti i test del progetto (nessuna regressione su test esistenti che toccano `LayerFeatureController`, `EcPoi`, `EcTrack`, route Nova).
+
+- [x] **Step 5: Commit**
+
+```bash
+git add tests/Feature/LayerFeatureControllerTest.php
+git commit -m "test(oc:8311): verifica rigenerazione PBF su sync di ecTracks"
+```
+
+---
+
+### Task 5: Correzione — filtro basato sul proprietario del layer, non sull'utente loggato
+
+**Contesto:** dopo il completamento dei Task 1-4 e la review finale, un test manuale in ambiente locale (apertura del layer id 130 in Nova) ha mostrato 0 feature disponibili nel pannello Ec Pois/Ec Tracks, pur esistendo centinaia di EC nel sistema. Causa: il layer 130 è di proprietà di `user_id=2` (che possiede 325 EcPoi), ma gli account Administrator usati per operare su Nova (`user_id` 1 e 9) possiedono 0 EcPoi ciascuno — il filtro `Auth::user()->id` introdotto nei Task 1-2 mostrava quindi 0 risultati per l'Administrator, rompendo l'operatività reale (gli account Administrator, in produzione, spesso gestiscono contenuti creati da altri, non propri).
+
+**Decisione presa col developer:** il filtro ownership deve essere sempre rispetto al **proprietario del layer** (`$layer->user_id`), non all'utente che effettua la richiesta. Per un Validator che apre il proprio layer non cambia nulla (`$layer->user_id` coincide col suo id); per un Administrator che apre il layer di un Validator, ora vede/gestisce gli EC di quel Validator.
+
+**Files:**
+- Modify: `app/Http/Controllers/LayerFeatureController.php` (sostituito il filtro `$user->id` con `$layer->user_id` in `getFeatures()` — sia `getAssociatedFeatures` che lista "altre disponibili" — e in `sync()` — sia ramo manuale che `auto=true`)
+- Test: `tests/Feature/LayerFeatureControllerTest.php` (test Administrator riscritti, nuovi test aggiunti)
+
+**Ulteriori correzioni emerse dalla review finale, applicate nello stesso ciclo:**
+- [x] Controllo di autorizzazione: solo il proprietario del layer o un Administrator possono chiamare `getFeatures()`/`sync()` per un dato `layerId`, altrimenti `abort(403)` (fail-closed: `if (! $user || ($layer->user_id !== $user->id && ! $user->hasRole('Administrator'))) { abort(403); }`)
+- [x] Allowlist sul parametro `model`: accetta `App\Models\EcPoi`, `App\Models\EcTrack`, `Wm\WmPackage\Models\EcPoi`, `Wm\WmPackage\Models\EcTrack` (il frontend Nova invia l'una o l'altra variante a seconda della config `wm-package.ec_poi_model`/`ec_track_model`) — istanziazione di classe arbitraria bloccata prima di `new $validatedData['model']`
+- [x] Catch dedicato per `ValidationException`/`ModelNotFoundException` prima del catch generico `\Exception`, per non trasformare 422/404 in 500
+- [x] Test: Validator che chiama `getFeatures`/`sync` su un layer non proprio riceve 403; `model` non in allowlist rifiutato con 400; Administrator che apre il layer di un Validator vede gli EC del Validator e non i propri
+
+**Verifica:** `docker exec laravel-camminiditalia php artisan test --filter=LayerFeatureControllerTest` → 15 passed (33 assertions). Suite completa: 142 passed, nessuna regressione imputabile a queste modifiche.
+
+- [x] **Commit** (istruzione testuale, non eseguita autonomamente)
+
+```bash
+git add app/Http/Controllers/LayerFeatureController.php app/Providers/NovaServiceProvider.php tests/Feature/LayerFeatureControllerTest.php CLAUDE.md docs/features/8311-visibilita-poi-tracce-non-proprie-pannello-manuale-layer/
+git commit -m "fix(oc:8311): filtro ownership basato su layer owner, autorizzazione 403 e allowlist modello"
+```
+
+---
+
+## Note post-implementazione (non task di codice)
+
+- **Deploy in produzione:** se è attivo `route:cache`, eseguire `php artisan route:clear` (o `route:cache` di nuovo) subito dopo il deploy — altrimenti la nuova route `sync/{layerId}` locale non sostituisce quella ereditata dal package e il fix di sicurezza non è effettivamente attivo.
+- **Fuori scope confermato in overview.md:** nessuna modifica al wm-package, nessun allineamento dell'override `getFeatures` alla logica taxonomy/auto-mode più recente del package, nessuna modifica a `LayerObserver` (oc:8080).
+- **Fuori scope, tracciato come nota:** `regeneratePbfsForLayer` viene chiamato due volte per un singolo sync di `ecTracks` (una volta esplicitamente dal controller, una volta da `LayerableObserver::created()` nel wm-package) — comportamento preesistente nel package, non introdotto da questo fix. Da valutare in un ticket futuro.

--- a/tests/Feature/LayerFeatureControllerTest.php
+++ b/tests/Feature/LayerFeatureControllerTest.php
@@ -6,6 +6,8 @@ use App\Models\EcPoi;
 use App\Models\EcTrack;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 use Wm\WmPackage\Models\App;
 use Wm\WmPackage\Models\Layer;
@@ -49,7 +51,7 @@ class LayerFeatureControllerTest extends TestCase
         \DB::table('layerables')->insert([
             'layer_id' => $layer->id,
             'layerable_id' => $poiOfB->id,
-            'layerable_type' => \App\Models\EcPoi::class,
+            'layerable_type' => EcPoi::class,
         ]);
 
         $response = $this->actingAs($validatorA)
@@ -70,7 +72,7 @@ class LayerFeatureControllerTest extends TestCase
         \DB::table('layerables')->insert([
             'layer_id' => $layer->id,
             'layerable_id' => $poiOfB->id,
-            'layerable_type' => \App\Models\EcPoi::class,
+            'layerable_type' => EcPoi::class,
         ]);
 
         $response = $this->actingAs($validatorA)
@@ -91,7 +93,7 @@ class LayerFeatureControllerTest extends TestCase
         \DB::table('layerables')->insert([
             'layer_id' => $layer->id,
             'layerable_id' => $poiOfOwner->id,
-            'layerable_type' => \App\Models\EcPoi::class,
+            'layerable_type' => EcPoi::class,
         ]);
 
         // POI di proprietà dell'admin stesso, non associato al layer: non deve comparire.
@@ -200,7 +202,7 @@ class LayerFeatureControllerTest extends TestCase
         \DB::table('layerables')->insert([
             'layer_id' => $layer->id,
             'layerable_id' => $poiOfOtherPreAssigned->id,
-            'layerable_type' => \App\Models\EcPoi::class,
+            'layerable_type' => EcPoi::class,
         ]);
 
         $ownPoi = $this->makePoi($validator->id);
@@ -223,8 +225,8 @@ class LayerFeatureControllerTest extends TestCase
         // il quale in ambiente di test (QUEUE_CONNECTION=sync) chiama la vera API DEM esterna.
         // Queue::fake()+Http::fake() evitano la chiamata di rete reale (stesso pattern di
         // LayerOwnershipTransferTest::setUp()), rendendo il test deterministico.
-        \Illuminate\Support\Facades\Queue::fake();
-        \Illuminate\Support\Facades\Http::fake();
+        Queue::fake();
+        Http::fake();
 
         $validator = $this->makeUser('Validator');
         $layer = Layer::factory()->create(['user_id' => $validator->id]);
@@ -284,7 +286,7 @@ class LayerFeatureControllerTest extends TestCase
         $layer = Layer::factory()->create(['user_id' => $validator->id]);
 
         $response = $this->actingAs($validator)
-            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(\App\Models\User::class).'&view_mode=edit&manual=1');
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(User::class).'&view_mode=edit&manual=1');
 
         $response->assertStatus(400);
     }
@@ -296,7 +298,7 @@ class LayerFeatureControllerTest extends TestCase
 
         $response = $this->actingAs($validator)
             ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
-                'model' => \App\Models\User::class,
+                'model' => User::class,
                 'features' => [],
             ]);
 
@@ -348,7 +350,7 @@ class LayerFeatureControllerTest extends TestCase
         \DB::table('layerables')->insert([
             'layer_id' => $layer->id,
             'layerable_id' => $poiOfFallbackOwner->id,
-            'layerable_type' => \App\Models\EcPoi::class,
+            'layerable_type' => EcPoi::class,
         ]);
 
         $otherOrphan = $this->makeUser('Validator');

--- a/tests/Feature/LayerFeatureControllerTest.php
+++ b/tests/Feature/LayerFeatureControllerTest.php
@@ -1,0 +1,389 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\EcPoi;
+use App\Models\EcTrack;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Services\PBFGeneratorService;
+use Wm\WmPackage\Services\RolesAndPermissionsService;
+
+class LayerFeatureControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        RolesAndPermissionsService::seedDatabase();
+        if (App::count() === 0) {
+            App::factory()->create();
+        }
+    }
+
+    private function makeUser(string $role): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole($role);
+
+        return $user;
+    }
+
+    private function makePoi(?int $userId)
+    {
+        return EcPoi::factory()->create(['user_id' => $userId, 'properties' => []]);
+    }
+
+    public function test_validator_does_not_see_ec_poi_of_another_validator_in_associated_features_edit_mode(): void
+    {
+        $validatorA = $this->makeUser('Validator');
+        $validatorB = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validatorA->id]);
+
+        $poiOfB = $this->makePoi($validatorB->id);
+        // Insert diretto per bypassare LayerableObserver, che su attach() riassegnerebbe user_id al proprietario del layer.
+        \DB::table('layerables')->insert([
+            'layer_id' => $layer->id,
+            'layerable_id' => $poiOfB->id,
+            'layerable_type' => \App\Models\EcPoi::class,
+        ]);
+
+        $response = $this->actingAs($validatorA)
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(EcPoi::class).'&view_mode=edit&manual=1');
+
+        $response->assertOk();
+        $ids = collect($response->json('features'))->pluck('id')->toArray();
+        $this->assertNotContains($poiOfB->id, $ids);
+    }
+
+    public function test_validator_does_not_see_ec_poi_of_another_validator_in_details_mode(): void
+    {
+        $validatorA = $this->makeUser('Validator');
+        $validatorB = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validatorA->id]);
+
+        $poiOfB = $this->makePoi($validatorB->id);
+        \DB::table('layerables')->insert([
+            'layer_id' => $layer->id,
+            'layerable_id' => $poiOfB->id,
+            'layerable_type' => \App\Models\EcPoi::class,
+        ]);
+
+        $response = $this->actingAs($validatorA)
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(EcPoi::class).'&view_mode=details&manual=1');
+
+        $response->assertOk();
+        $ids = collect($response->json('features'))->pluck('id')->toArray();
+        $this->assertNotContains($poiOfB->id, $ids);
+    }
+
+    public function test_administrator_sees_ec_poi_of_layer_owner_in_associated_features(): void
+    {
+        $admin = $this->makeUser('Administrator');
+        $layerOwner = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $layerOwner->id]);
+
+        $poiOfOwner = $this->makePoi($layerOwner->id);
+        \DB::table('layerables')->insert([
+            'layer_id' => $layer->id,
+            'layerable_id' => $poiOfOwner->id,
+            'layerable_type' => \App\Models\EcPoi::class,
+        ]);
+
+        // POI di proprietà dell'admin stesso, non associato al layer: non deve comparire.
+        $poiOfAdmin = $this->makePoi($admin->id);
+
+        $response = $this->actingAs($admin)
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(EcPoi::class).'&view_mode=edit&manual=1');
+
+        $response->assertOk();
+        $ids = collect($response->json('features'))->pluck('id')->toArray();
+        $this->assertContains($poiOfOwner->id, $ids);
+        $this->assertNotContains($poiOfAdmin->id, $ids);
+    }
+
+    public function test_validator_sees_own_ec_poi_in_associated_features(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $ownPoi = $this->makePoi($validator->id);
+        $layer->ecPois()->attach($ownPoi->id);
+
+        $response = $this->actingAs($validator)
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(EcPoi::class).'&view_mode=edit&manual=1');
+
+        $response->assertOk();
+        $ids = collect($response->json('features'))->pluck('id')->toArray();
+        $this->assertContains($ownPoi->id, $ids);
+    }
+
+    public function test_validator_sync_filters_out_ec_poi_not_owned(): void
+    {
+        $validatorA = $this->makeUser('Validator');
+        $validatorB = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validatorA->id]);
+
+        $ownPoi = $this->makePoi($validatorA->id);
+        $poiOfB = $this->makePoi($validatorB->id);
+
+        $response = $this->actingAs($validatorA)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcPoi::class,
+                'features' => [$ownPoi->id, $poiOfB->id],
+            ]);
+
+        $response->assertOk();
+        $assignedIds = $response->json('assigned_ids');
+        $this->assertContains($ownPoi->id, $assignedIds);
+        $this->assertNotContains($poiOfB->id, $assignedIds);
+        $this->assertTrue($layer->ecPois()->where('ec_pois.id', $ownPoi->id)->exists());
+        $this->assertFalse($layer->ecPois()->where('ec_pois.id', $poiOfB->id)->exists());
+    }
+
+    public function test_administrator_sync_filters_out_ec_poi_not_owned(): void
+    {
+        $admin = $this->makeUser('Administrator');
+        $otherOwner = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $admin->id]);
+
+        $ownPoi = $this->makePoi($admin->id);
+        $poiOfOther = $this->makePoi($otherOwner->id);
+
+        $response = $this->actingAs($admin)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcPoi::class,
+                'features' => [$ownPoi->id, $poiOfOther->id],
+            ]);
+
+        $response->assertOk();
+        $assignedIds = $response->json('assigned_ids');
+        $this->assertContains($ownPoi->id, $assignedIds);
+        $this->assertNotContains($poiOfOther->id, $assignedIds);
+    }
+
+    public function test_sync_auto_true_assigns_only_owned_ec_pois_ignoring_taxonomy(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $otherValidator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $ownPoiA = $this->makePoi($validator->id);
+        $ownPoiB = $this->makePoi($validator->id);
+        $poiOfOther = $this->makePoi($otherValidator->id);
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcPoi::class,
+                'auto' => true,
+            ]);
+
+        $response->assertOk();
+        $assignedIds = $response->json('assigned_ids');
+        $this->assertContains($ownPoiA->id, $assignedIds);
+        $this->assertContains($ownPoiB->id, $assignedIds);
+        $this->assertNotContains($poiOfOther->id, $assignedIds);
+    }
+
+    public function test_sync_auto_true_replaces_pivot_with_only_callers_ec_pois(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $otherValidator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $poiOfOtherPreAssigned = $this->makePoi($otherValidator->id);
+        // Insert diretto per bypassare LayerableObserver, che su attach() riassegnerebbe user_id al proprietario del layer.
+        \DB::table('layerables')->insert([
+            'layer_id' => $layer->id,
+            'layerable_id' => $poiOfOtherPreAssigned->id,
+            'layerable_type' => \App\Models\EcPoi::class,
+        ]);
+
+        $ownPoi = $this->makePoi($validator->id);
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcPoi::class,
+                'auto' => true,
+            ]);
+
+        $response->assertOk();
+        $assignedIds = $response->json('assigned_ids');
+        $this->assertContains($ownPoi->id, $assignedIds);
+        $this->assertNotContains($poiOfOtherPreAssigned->id, $assignedIds);
+    }
+
+    public function test_sync_ec_tracks_triggers_pbf_regeneration(): void
+    {
+        // EcTrackObserver::created() dispatcha una Bus::chain che include UpdateEcTrack3DDemJob,
+        // il quale in ambiente di test (QUEUE_CONNECTION=sync) chiama la vera API DEM esterna.
+        // Queue::fake()+Http::fake() evitano la chiamata di rete reale (stesso pattern di
+        // LayerOwnershipTransferTest::setUp()), rendendo il test deterministico.
+        \Illuminate\Support\Facades\Queue::fake();
+        \Illuminate\Support\Facades\Http::fake();
+
+        $validator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+        $ownTrack = EcTrack::factory()->create(['user_id' => $validator->id, 'properties' => []]);
+
+        $pbfMock = \Mockery::mock(PBFGeneratorService::class);
+        // Il flusso di sync di una singola traccia invoca regeneratePbfsForLayer da due
+        // path indipendenti: LayerFeatureController::sync() (chiamata esplicita per la
+        // relazione ecTracks) e Wm\WmPackage\Observers\LayerableObserver::created()
+        // (fired dal pivot Layerable creato tramite ->sync(), che usa un custom pivot
+        // model e quindi dispatcha eventi Eloquent). Per una sola traccia il totale è 2.
+        $pbfMock->shouldReceive('regeneratePbfsForLayer')
+            ->twice()
+            ->withArgs(fn (Layer $l) => $l->id === $layer->id);
+        $this->app->instance(PBFGeneratorService::class, $pbfMock);
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcTrack::class,
+                'features' => [$ownTrack->id],
+            ]);
+
+        $response->assertOk();
+    }
+
+    public function test_validator_gets_403_calling_get_features_on_layer_not_owned(): void
+    {
+        $validatorA = $this->makeUser('Validator');
+        $validatorB = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validatorB->id]);
+
+        $response = $this->actingAs($validatorA)
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(EcPoi::class).'&view_mode=edit&manual=1');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_validator_gets_403_calling_sync_on_layer_not_owned(): void
+    {
+        $validatorA = $this->makeUser('Validator');
+        $validatorB = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validatorB->id]);
+        $poi = $this->makePoi($validatorA->id);
+
+        $response = $this->actingAs($validatorA)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcPoi::class,
+                'features' => [$poi->id],
+            ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_get_features_rejects_model_not_in_allowlist(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $response = $this->actingAs($validator)
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(\App\Models\User::class).'&view_mode=edit&manual=1');
+
+        $response->assertStatus(400);
+    }
+
+    public function test_sync_rejects_model_not_in_allowlist(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => \App\Models\User::class,
+                'features' => [],
+            ]);
+
+        $response->assertStatus(400);
+    }
+
+    public function test_get_features_accepts_wm_package_ec_poi_model_alias(): void
+    {
+        // Il frontend Nova invia il valore letto da config('wm-package.ec_poi_model'), che
+        // di default (chiave non configurata) risolve a Wm\WmPackage\Models\EcPoi, non
+        // App\Models\EcPoi. L'allowlist deve accettare entrambe le varianti.
+        $validator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+
+        $response = $this->actingAs($validator)
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(\Wm\WmPackage\Models\EcPoi::class).'&view_mode=edit&manual=1');
+
+        $response->assertOk();
+    }
+
+    public function test_sync_ec_pois_does_not_trigger_pbf_regeneration(): void
+    {
+        $validator = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $validator->id]);
+        $ownPoi = $this->makePoi($validator->id);
+
+        $pbfMock = \Mockery::mock(PBFGeneratorService::class);
+        $pbfMock->shouldNotReceive('regeneratePbfsForLayer');
+        $this->app->instance(PBFGeneratorService::class, $pbfMock);
+
+        $response = $this->actingAs($validator)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcPoi::class,
+                'features' => [$ownPoi->id],
+            ]);
+
+        $response->assertOk();
+    }
+
+    public function test_admin_on_orphaned_layer_sees_only_default_owner_ec_poi(): void
+    {
+        $admin = $this->makeUser('Administrator');
+        $fallbackOwner = $this->makeUser('Validator');
+        config(['camminiditalia.default_owner_id' => $fallbackOwner->id]);
+
+        $layer = Layer::factory()->create(['user_id' => null]);
+
+        $poiOfFallbackOwner = $this->makePoi($fallbackOwner->id);
+        \DB::table('layerables')->insert([
+            'layer_id' => $layer->id,
+            'layerable_id' => $poiOfFallbackOwner->id,
+            'layerable_type' => \App\Models\EcPoi::class,
+        ]);
+
+        $otherOrphan = $this->makeUser('Validator');
+        $poiOfOtherOrphanOwner = $this->makePoi($otherOrphan->id);
+
+        $response = $this->actingAs($admin)
+            ->getJson('/nova-vendor/layer-features/features/'.$layer->id.'?model='.urlencode(EcPoi::class).'&view_mode=edit&manual=1');
+
+        $response->assertOk();
+        $ids = collect($response->json('features'))->pluck('id')->toArray();
+        $this->assertContains($poiOfFallbackOwner->id, $ids);
+        $this->assertNotContains($poiOfOtherOrphanOwner->id, $ids);
+    }
+
+    public function test_sync_auto_true_on_orphaned_layer_assigns_only_default_owner_ec_poi(): void
+    {
+        $admin = $this->makeUser('Administrator');
+        $fallbackOwner = $this->makeUser('Validator');
+        config(['camminiditalia.default_owner_id' => $fallbackOwner->id]);
+
+        $layer = Layer::factory()->create(['user_id' => null]);
+
+        $ownPoi = $this->makePoi($fallbackOwner->id);
+        $otherOrphan = $this->makeUser('Validator');
+        $poiOfOtherOrphanOwner = $this->makePoi($otherOrphan->id);
+
+        $response = $this->actingAs($admin)
+            ->postJson('/nova-vendor/layer-features/sync/'.$layer->id, [
+                'model' => EcPoi::class,
+                'auto' => true,
+            ]);
+
+        $response->assertOk();
+        $assignedIds = $response->json('assigned_ids');
+        $this->assertContains($ownPoi->id, $assignedIds);
+        $this->assertNotContains($poiOfOtherOrphanOwner->id, $assignedIds);
+    }
+}


### PR DESCRIPTION
## Summary
- Un Validator vedeva/poteva sincronizzare POI/tracce (EC) non proprie nel pannello manuale di gestione layer (`getFeatures`/`sync`).
- Filtro ownership ora basato sul **proprietario del layer** (`$layer->user_id`), non sull'utente loggato — nessuna eccezione di ruolo (vedi `docs/features/8311-.../overview.md` per la motivazione).
- Nuovo override locale di `sync()` con controllo di autorizzazione 403 (solo proprietario del layer o Administrator) e allowlist sul parametro `model`.
- Fallback al proprietario di default (`camminiditalia@webmapp.it`, config `camminiditalia.default_owner_id`) per i layer orfani (`user_id` null) — corretto un data leak su EC orfani emerso durante `wm-review-ticket`.
- Ticket di follow-up aperto: oc:8314 (modalità auto/manuale non persistita lato backend).

## Test plan
- [x] `docker exec laravel-camminiditalia php artisan test --filter=LayerFeatureControllerTest` — 17 passed
- [x] `docker exec laravel-camminiditalia php artisan test` (suite completa) — 145 passed, nessuna regressione
- [x] Review con `wm-skills:wm-review-ticket` (5 finder paralleli) — 1 blocker trovato e corretto (layer orfano), cleanup residui documentati in `notes.md`

Ticket: oc:8311

🤖 Generated with [Claude Code](https://claude.com/claude-code)