### PR TITLE
fix(oc:8314): persisti modalita auto/manuale del layer lato backend

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -119,3 +119,5 @@ JWT_SECRET=testing-only-not-a-real-secret
 
 # AWS_DUMPS_* omesse: credenziali reali di accesso ai backup di produzione,
 # non necessarie ai test e assenti anche da .env-example/.env-deploy
+# oc:8314: stesso default di .env — vedi commento lì.
+DEFAULT_LAYER_MODE=manual

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,8 +125,34 @@ La relazione user → layer è `$user->layers()` (`HasMany` via `user_id` su tab
 | Colonna layer linkabile e filtro layer su UgcPoi/UgcTrack | oc:8276 | `app/Nova/Traits/HasLayerFilterAndLink.php`, `app/Nova/UgcPoi.php`, `app/Nova/UgcTrack.php` | Field "layer" (link verso il layer, in nuova scheda) e filtro Select per layer, solo Administrator; trait condiviso tra UgcPoi e UgcTrack |
 | Fix drift phpstan-baseline.neon | oc:8312 | `phpstan-baseline.neon`, `app/Nova/Layer.php`, `app/Nova/Traits/HasLayerFilterAndLink.php`, `app/Policies/TaxonomyPoiTypePolicy.php`, `tests/Feature/AppHomeLayerSortButtonTest.php`, `tests/Feature/LayerOwnershipTransferTest.php` | Baseline rigenerato allineato a PHPStan 2.1.38/Larastan 3.9.2; 18 fix reali (docblock orfano, firma closure Nova, return espliciti in policy, asserzioni/chiamate test obsolete), 31 entry baseline per falsi positivi migration + gap tipizzazione wm-package |
 | Database PostgreSQL separato per i test PHPUnit | oc:8092 | `.env.testing`, `phpunit.xml`, `.github/workflows/run-tests.yml`, `CLAUDE.md` | I test girano su `camminiditalia_testing` (clonato da `template_postgis`), non più sul DB di sviluppo condiviso; `RefreshDatabase` non svuota più i dati locali |
+| Modalità auto/manuale layer persistita + blocco auto per owner Administrator | oc:8314 | `app/Http/Controllers/LayerFeatureController.php`, `tests/Feature/LayerFeatureControllerTest.php`, `.env`, `.env.testing` | `track_mode`/`poi_mode` ora persistiti su `sync()`; `auto:true` rifiutato (422) per layer con owner Administrator; default modalità camminiditalia = `manual` (`DEFAULT_LAYER_MODE`) |
 
 ## Decisioni architetturali
+
+### Modalità auto/manuale del layer persistita lato backend (oc:8314)
+- persistMode() nel controller locale eredita dal package (protected), nessuna
+  duplicazione della logica di persistenza; il ramo auto/manuale locale
+  (whitelist modelli, filtro user_id=layerOwnerId) resta specifico di
+  camminiditalia e NON delega a parent::sync() (scelta di oc:8311, invariata)
+- Layer con owner (risolto: user_id ?? default_owner_id) di ruolo Administrator:
+  auto:true viene rifiutato con 422 esplicito nel controller locale (non nel
+  package: Wm\WmPackage\Models\Layer non ha un override locale utilizzabile, 22
+  punti nel package lo referenziano direttamente). Copertura parziale: blocca
+  solo il salvataggio via questo endpoint, non il valore mostrato in UI al
+  primo caricamento per layer non ancora toccati
+- Default della modalità (quando configuration non ha track_mode/poi_mode)
+  cambiato da 'auto' a 'manual' per camminiditalia via nuova chiave config
+  wm-package.default_layer_mode (env DEFAULT_LAYER_MODE) — il default 'auto'
+  resta invariato per gli altri progetti Webmapp
+- Bug scoperto ma non corretto in questo ciclo: 35 layer su 118 hanno tutte le
+  tracce associate con user_id diverso dal proprietario del layer (verificato
+  su due dump distinti, 28/07 e 23/08, stesso conteggio) — la vista Nova
+  (edit/detail) le nasconde sempre (filtro where('user_id', $layerOwnerId)).
+  Causa probabile: LayerObserver (oc:8080) trasferisce ownership solo al
+  cambio di user_id del layer, non quando vengono aggiunte tracce con owner
+  diverso al pivot in un secondo momento. Decisione: nessuna correzione bulk
+  sui dati, il cliente verrà informato caso per caso e correggerà lui stesso
+  da Nova
 
 ### Database PostgreSQL separato per i test PHPUnit (oc:8092)
 - `.env.testing` è committato direttamente (non `.example`) ma **non è una copia integrale del `.env` locale**: `APP_KEY`/`JWT_SECRET`/`AWS_DUMPS_ACCESS_KEY_ID`/`AWS_DUMPS_SECRET_ACCESS_KEY` vanno sempre rigenerati/omessi (trovato in review: la prima stesura conteneva questi segreti reali copiati 1:1 dal `.env` personale, incluse credenziali AWS con accesso ai backup di produzione)

--- a/app/Http/Controllers/LayerFeatureController.php
+++ b/app/Http/Controllers/LayerFeatureController.php
@@ -173,7 +173,8 @@ class LayerFeatureController extends WmLayerFeatureController
             $validatedData = $request->validate([
                 'features' => 'array',
                 'model' => 'required|string',
-                'auto' => 'boolean',
+                'auto' => ['boolean', 'prohibits:manual'],
+                'manual' => ['boolean', 'prohibits:auto'],
             ]);
 
             if (! in_array($validatedData['model'], [
@@ -206,10 +207,22 @@ class LayerFeatureController extends WmLayerFeatureController
             $isAutoRequest = ! empty($validatedData['auto']) && in_array($relationName, ['ecTracks', 'ecPois']);
 
             if ($isAutoRequest) {
+                $owner = User::find($layerOwnerId);
+
+                if ($owner && $owner->hasRole('Administrator')) {
+                    return response()->json([
+                        'error' => 'Il proprietario di questo layer è un Amministratore: non è possibile attivare la modalità automatica, verrebbero assegnate tutte le tracce/POI di sistema di sua proprietà.',
+                    ], 422);
+                }
+            }
+
+            $this->persistMode($layer, $relationName, $request);
+
+            if ($isAutoRequest) {
                 $ownedIds = $model->newQuery()->where('user_id', $layerOwnerId)->pluck('id')->toArray();
 
                 $layer->{$relationName}()->sync($ownedIds);
-            } else {
+            } elseif ($request->has('features')) {
                 $requestedIds = $validatedData['features'] ?? [];
 
                 $ownedIds = $model->newQuery()->whereIn('id', $requestedIds)->where('user_id', $layerOwnerId)->pluck('id')->toArray();
@@ -217,7 +230,9 @@ class LayerFeatureController extends WmLayerFeatureController
                 $layer->{$relationName}()->sync($ownedIds);
             }
 
-            if ($relationName === 'ecTracks') {
+            $pivotSynced = $isAutoRequest || $request->has('features');
+
+            if ($pivotSynced && $relationName === 'ecTracks') {
                 app(PBFGeneratorService::class)->regeneratePbfsForLayer($layer);
             }
 

--- a/docs/features/8314-modalita-auto-manuale-layer-non-persistita/notes.md
+++ b/docs/features/8314-modalita-auto-manuale-layer-non-persistita/notes.md
@@ -1,0 +1,41 @@
+> Ticket: oc:8314
+
+# Notes — Modalità auto/manuale del layer non persistita lato backend
+
+## Deviazioni dal piano
+
+Durante la verifica end-to-end in ambiente Nova reale (dopo l'esecuzione del piano) sono emersi due requisiti aggiuntivi, non presenti nell'overview/piano originali, richiesti esplicitamente dal developer e implementati nello stesso ciclo:
+
+1. **Rifiuto esplicito di `auto: true` per layer con owner Administrator.** Scoperto testando il layer 129 (owner `user_id=2`, Administrator, 550 tracce totali nel sistema): attivare "auto" tramite il ramo esistente del controller locale (`sync($ownedIds)` con `$ownedIds` = tutte le tracce del proprietario, logica di oc:8311) assegnava indiscriminatamente tutte e 550 le tracce dell'Administrator al layer. Il controllo (`hasRole('Administrator')` sull'owner risolto, `user_id ?? default_owner_id`) è stato aggiunto **solo nel controller locale** (`app/Http/Controllers/LayerFeatureController.php::sync()`), non nel package — deliberatamente: `Wm\WmPackage\Models\Layer` non ha un override locale utilizzabile (22 punti nel package lo referenziano direttamente, nessun binding via config come per `EcTrack`/`EcPoi`), quindi la copertura è limitata al salvataggio via questo endpoint. La UI può ancora mostrare "auto" al primo caricamento per un layer con owner Administrator finché non si tenta di attivarlo esplicitamente (limite noto, accettato).
+   - Risposta 422 con messaggio esplicito ("Il proprietario di questo layer è un Amministratore: non è possibile attivare la modalità automatica...").
+   - Frontend (`LayerFeature.vue::handleModeChange`) aggiornato per mostrare il messaggio specifico ricevuto dal backend invece del generico "Errore durante il cambio di modalità".
+   - Test: `test_sync_rejects_auto_true_when_layer_owner_is_administrator`, `test_sync_rejects_auto_true_when_resolved_owner_is_administrator_via_default_owner_id`, `test_sync_allows_manual_true_even_when_layer_owner_is_administrator`.
+
+2. **Default del flag di modalità cambiato da `'auto'` a `'manual'` per camminiditalia.** Argomentazione del developer, verificata nel codice/dati: il default `'auto'` ha senso solo nel modello originale del package (auto = ricalcolo da tassonomia); su camminiditalia non si usano tassonomie sui layer (0 su 118 verificato) — le tappe sono sempre selezionate manualmente (pivot diretto). Implementato con un pattern di configurabilità già in uso nel progetto (stesso schema di `ec_track_model`): nuova chiave `wm-package.default_layer_mode` (default `'auto'`, invariato per gli altri progetti Webmapp), sovrascritta da camminiditalia con `DEFAULT_LAYER_MODE=manual` in `.env`/`.env.testing`. `isAutoTrackMode()`/`isAutoPoiMode()` nel modello `Layer` (package) usano questo config come fallback invece del literal `'auto'`.
+   - Nessuna scrittura sui dati esistenti: cambia solo come viene **letto** lo stato assente di `configuration`, reversibile rimuovendo la env var.
+   - Test: `test_layer_without_configuration_defaults_to_manual_mode_on_camminiditalia`.
+   - Verificato nessun test esistente (repo principale) dipendeva dal default implicito `'auto'` prima del cambiamento.
+
+## Bug trovati (fuori scope, non corretti in questo ciclo)
+
+**Disallineamento ownership layer/tracce — 35 layer su 118 (verificato sia sul dump del 28/07 sia su quello del 23/08, stesso conteggio in entrambi).**
+
+Scoperto testando il layer 124: owner del layer `user_id=2` (Administrator), ma le 23 tracce nel pivot `layerables` appartengono tutte a `user_id=3816` ("Vie Francigene di Sicilia", ruolo Validator, 58 tracce totali di sua proprietà, **0 layer posseduti**). Il controller locale filtra sempre `getAssociatedFeatures()`/`getFeatures()` con `where('user_id', $layerOwnerId)` (oltre al filtro di associazione) — quindi queste tracce, pur essendo nel pivot, non vengono mai mostrate nella UI Nova (edit e detail): il layer appare vuoto ("Nessun dato disponibile") pur avendo tracce realmente associate.
+
+Verifica estesa a tutti i 118 layer: **35 hanno il 100% delle proprie tracce con `user_id` diverso dal proprietario del layer** — quasi tutti con owner `user_id=2` (Administrator) o `user_id=9` (altro Administrator).
+
+Causa più probabile: il meccanismo di trasferimento ownership esistente (`LayerObserver`, oc:8080) scatta solo quando **cambia l'owner del layer** (`wasChanged('user_id')`), non quando vengono aggiunte tracce con owner diverso al pivot in un secondo momento — quindi non corregge mai questo tipo di disallineamento, generato probabilmente da import/sync storici o da gestori (come 3816) le cui tracce sono state associate a un layer rimasto sotto l'Administrator di default, senza che il layer venisse mai riassegnato a loro.
+
+**Non è causato da oc:8314**: `getFeatures()` (locale) non è mai stato toccato in questo ciclo (dichiarato fuori scope negli overview fin dall'inizio). Il problema esiste indipendentemente dal lavoro di questo ticket, ed è stabile nel tempo (nessun peggioramento/miglioramento automatico tra i due dump verificati).
+
+**Decisione del developer**: nessuna correzione bulk sui dati in questo ciclo. Se il cliente segnala tracce mancanti in un layer, va spiegato il problema (disallineamento ownership layer/tracce) e lasciato che lo corregga lui stesso dal pannello Nova (riassegnando owner del layer o delle tracce, secondo la sua conoscenza di chi sia il vero gestore).
+
+## Decisioni
+
+- Il gitlink di `wm-package` verrà aggiornato al momento del commit reale (non durante l'esecuzione, per l'override no-commit imposto da `wm-plan`) — vedi Task 6 del piano, marcato "non applicabile in questa fase" nel ledger SDD.
+- Ambiente di sviluppo ripristinato due volte durante la verifica: prima con un dump datato 28/07 (per riportare il layer 129 allo stato pre-esperimento dopo un test del ramo `auto`), poi con un dump più recente (23/08, scaricato da `wm:download-db-backup`) per verificare che il disallineamento ownership non fosse un artefatto di un dump vecchio — confermato presente in entrambi.
+
+## Follow-up
+
+- Ticket separato da aprire (fuori da oc:8314): disallineamento ownership su 35 layer, decisione rimandata al cliente/dev in un ciclo successivo.
+- Refactor eventuale: introdurre un `layer_model` configurabile nel package (analogo a `ec_track_model`/`ec_poi_model`) per permettere override locali del modello `Layer` — servirebbe a coprire in modo completo (anche in UI al caricamento) regole di business specifiche come "owner Administrator → mai auto", oggi limitate al solo controller locale.

--- a/docs/features/8314-modalita-auto-manuale-layer-non-persistita/overview.md
+++ b/docs/features/8314-modalita-auto-manuale-layer-non-persistita/overview.md
@@ -1,0 +1,158 @@
+> Ticket: oc:8314
+
+# Modalità auto/manuale del layer non persistita lato backend
+
+## Cosa cambia
+
+Il passaggio da modalità automatica a manuale nel campo Nova `LayerFeatures`
+(pannelli "Ec Tracks" / "Ec Pois" della resource Layer) viene persistito sul
+layer in `configuration->track_mode` / `configuration->poi_mode`. Dopo il fix:
+
+- cliccando il toggle "manuale" il layer passa **immediatamente** in manuale
+  lato backend, con la selezione già presente in auto come punto di partenza;
+- ricaricando la pagina il toggle riflette la modalità reale del layer, non più
+  il default `auto`;
+- il ritorno in automatico scrive esplicitamente `'auto'` invece di affidarsi al
+  default implicito, rendendo il flag auditabile dal DB.
+
+Questo repo contiene una modifica minima: l'override locale di `sync()` —
+**l'unico** controller che serve la route su camminiditalia — invoca il nuovo
+metodo `persistMode()` del package. Nessuna logica di persistenza duplicata qui.
+Insieme alla chiamata, questo repo ospita **tutti** i test del fix.
+Frontend, controller base e implementazione di `persistMode()` stanno in
+`wm-package` (vedi overview omonimo in quel repo).
+
+## Perché
+
+Bug riprodotto durante i test di oc:8311. I metodi `Layer::setTrackMode()` e
+`Layer::setPoiMode()` (`wm-package/src/Models/Layer.php:158,171`) esistono ma non
+sono chiamati da nessun punto del codice: sono metodi morti. Nessuna delle due
+implementazioni di `sync()` — né quella del package né l'override locale
+introdotto da oc:8311 — persiste la modalità.
+
+Conseguenza: l'utente lavora e salva in manuale, ma `configuration` resta vuota,
+il default `?? 'auto'` prevale e al reload la UI mostra "auto". Il lavoro svolto
+non viene perso (il pivot `layerables` è salvato correttamente) ma la modalità sì,
+e l'utente non ha modo di capire in quale stato sia il layer.
+
+Verificato sul DB locale (dump di produzione): **tutti i 118 layer hanno
+`configuration` vuota** — il flag non è mai stato scritto da nessuno.
+
+## Requisiti
+
+- [ ] `POST /nova-vendor/layer-features/sync/{layerId}` accetta un flag `manual`
+      (boolean, opzionale) accanto al già presente `auto`, mutuamente esclusivi
+      via `prohibits` (coerente con la validazione del package)
+- [ ] L'override locale di `sync()` **non duplica** la logica di persistenza:
+      invoca `persistMode()` ereditato dal package (una sola chiamata)
+- [ ] Con `manual: true` la modalità persistita è `manual` sulla chiave corretta:
+      `track_mode` per la relazione `ecTracks`, `poi_mode` per `ecPois`
+- [ ] Con `auto: true` la modalità persistita è **esplicitamente** `'auto'`
+      sulla stessa chiave, invece di lasciare `configuration` intatta
+- [ ] Una chiamata senza né `auto` né `manual` non modifica la modalità
+      (retrocompatibilità: nessun client esistente viene rotto)
+- [ ] Il passaggio a manuale **non svuota** il pivot `layerables`: gli EC già
+      associati in automatico restano associati e costituiscono l'init del manuale
+- [ ] La scrittura della modalità preserva le altre chiavi eventualmente presenti
+      in `configuration` (merge, non sostituzione)
+- [ ] Un layer con `configuration` `NULL` (stato attuale di tutti i layer in
+      produzione) accetta la prima scrittura senza errori
+- [ ] Il filtro di ownership introdotto da oc:8311 resta invariato: la modalità si
+      persiste solo dopo il controllo `403` su proprietario/Administrator
+- [ ] `[UX]` La modalità mostrata nel toggle al caricamento della pagina
+      corrisponde sempre alla modalità persistita sul layer
+- [ ] `[Aggiuntivo, emerso in verifica]` Una richiesta `auto: true` per un layer
+      il cui proprietario (`user_id` risolto: `user_id` del layer o
+      `default_owner_id`) ha ruolo Administrator viene rifiutata con `422` e un
+      messaggio esplicito, mostrato all'utente nel frontend
+- [ ] `[Aggiuntivo, emerso in verifica]` Un layer senza `track_mode`/`poi_mode`
+      in `configuration` è considerato **manuale** su camminiditalia (non
+      `auto`), tramite la chiave configurabile `wm-package.default_layer_mode`
+
+## Rischi
+
+- **Semantica di `manual` più forte del solo stato UI.** Il flag è letto da tre
+  consumatori, non solo dalla UI: `LayerFeatures.php:75` (stato iniziale del
+  toggle), `EcTrackObserver.php:137` (filtra i layer `auto` per dispatchare
+  `SyncAutoLayerAfterTrackTaxonomyChangeJob`) e `Layer.php:358` (fallback in
+  lettura che ricostruisce i trackIds da tassonomia). Scrivere `manual` **spegne**
+  per quel layer il ricalcolo automatico — comportamento confermato come voluto
+  ("se vado in manuale non devo essere più modificato automaticamente").
+  *Stato attuale, non garanzia di codice:* su camminiditalia oggi il rischio non
+  si manifesta perché **zero layer hanno `taxonomyActivities`** (0 righe in
+  `taxonomy_activityables` per il morph Layer): l'observer non dispatcha mai e il
+  fallback tassonomico è inerte. Ma è una fotografia dei dati, non un vincolo di
+  codice: `taxonomyActivities` è un campo Nova modificabile
+  (`MorphToMany::make('Activities', ...)`, `wm-package/src/Nova/Layer.php:93`) —
+  un Administrator può associare tassonomie a un layer in qualsiasi momento senza
+  alcun blocco. La correttezza del fix non dipende da questo stato: la
+  persistenza della modalità (ordine `persistMode()` → assign, scrittura atomica
+  via `jsonb_set`) resta valida a prescindere da quante tassonomie esistano oggi
+  o in futuro.
+
+- **Il fix è diviso su due repo e nessuno dei due basta da solo.** L'override
+  locale non chiama `parent::sync()`, quindi un fix solo nel package non arriva a
+  camminiditalia; il frontend Vue esiste solo nel package, quindi il flag non può
+  essere inviato senza toccarlo. *Mitigazione:* la logica di persistenza vive una
+  sola volta, nel metodo `protected persistMode()` del package, e l'override
+  locale la invoca — nessuna duplicazione, un solo punto da correggere per
+  eventuali fix futuri sulla modalità. L'override continua a **non** delegare
+  `sync()` al parent: i due metodi condividono solo la firma (autorizzazione 403,
+  whitelist dei modelli, filtro `user_id = layerOwnerId` sugli ID sia in auto che
+  in manuale, e un ramo `auto` che qui significa "assegna tutti gli EC di cui sono
+  proprietario" invece di "ricalcola da tassonomia"). Rifare l'override in termini
+  di `parent::sync()` è un refactor di oc:8311, fuori scope.
+
+- **Stato del submodule `wm-package` — risolto prima di questo aggiornamento.**
+  Il submodule era stato lasciato in detached HEAD su `60f88f45`, un commit
+  indietro rispetto a `origin/develop`. Verificato che `ae6d5cf` (visto in una
+  sessione precedente) appartiene al branch `origin/RDO_ass_cammini_italia_2026_2`
+  e **non tocca** alcun file sotto `src/Nova/Fields/LayerFeatures/`: nessun
+  rischio di sovrascrittura con questo fix. Il submodule è stato riallineato su
+  branch `develop`, HEAD `db707c8a`, 0/0 rispetto a `origin/develop`; il repo
+  principale è anch'esso 0/0 su `origin/develop`. Il gitlink del repo principale
+  (`git ls-tree HEAD wm-package`) non è ancora aggiornato al nuovo commit del
+  submodule: sarà incluso nel commit del fix.
+
+- **Un click esplorativo sul toggle diventa persistente.** Con la persistenza al
+  toggle (scelta confermata), l'utente che clicca "manuale" per curiosità lascia
+  il layer in manuale anche chiudendo senza salvare. *Mitigazione:* l'operazione è
+  reversibile e il ritorno in auto è già presidiato da `ConfirmModal`; la
+  selezione ereditata dall'auto rende il layer immediatamente coerente, non
+  svuotato.
+
+- **Il ritorno in auto resta distruttivo.** `auto: true` esegue
+  `sync($ownedIds)` sovrascrivendo la selezione manuale con "tutti gli EC di cui
+  sei proprietario". *Mitigazione:* comportamento intenzionale e preesistente
+  (oc:8311), confermato da modale; non modificato in questo ciclo.
+
+## Out of scope
+
+- Modifica del comportamento distruttivo del ritorno in automatico
+- Migrazione dati per popolare `configuration` sui layer esistenti: il default
+  `auto` è già quello corretto per tutti e 118, nessun backfill necessario
+- Rimozione dell'override locale di `sync()` in favore di una delega a
+  `parent::sync()` — refactor legittimo ma indipendente da questo bug: i due
+  metodi divergono su autorizzazione, whitelist modelli, filtro di ownership sugli
+  ID e semantica del ramo `auto`
+- Estrazione in chiavi i18n dei messaggi Vue hardcoded in italiano
+  (`Nova.success("Modalità automatica attivata")`): debito preesistente del
+  package, tracciato in `notes.md`
+- Introduzione di tassonomie sui layer di camminiditalia
+- Modifica di `getFeatures()`, che su questo repo ignora deliberatamente la
+  modalità (oc:8311)
+
+## Moduli toccati
+
+**Repo camminiditalia (questo repo):**
+
+| File | Modifica |
+|---|---|
+| `app/Http/Controllers/LayerFeatureController.php` | `sync()`: validazione `manual` + una chiamata a `persistMode()` ereditato dal package; rifiuto esplicito (422) di `auto: true` per owner Administrator |
+| `tests/Feature/LayerFeatureControllerTest.php` | Test su persistenza modalità, pivot, merge di `configuration`, rifiuto `auto` per owner Administrator, default `manual` |
+| `.env`, `.env.testing` | `DEFAULT_LAYER_MODE=manual` |
+
+**Repo wm-package (submodule):** vedi
+`wm-package/docs/features/8314-modalita-auto-manuale-layer-non-persistita/overview.md`
+— frontend (`useFeatures.ts`, `LayerFeature.vue`), nuovo `protected persistMode()`
+e `sync()` del controller base.

--- a/docs/features/8314-modalita-auto-manuale-layer-non-persistita/plan.md
+++ b/docs/features/8314-modalita-auto-manuale-layer-non-persistita/plan.md
@@ -1,0 +1,787 @@
+> Ticket: oc:8314
+
+# Modalità auto/manuale del layer non persistita lato backend — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Nessun commit o branch automatico.** I comandi `git commit`/`git push`/`git checkout -b` mostrati in questo piano sono istruzioni testuali per lo sviluppatore, non azioni da eseguire in autonomia. L'esecutore scrive solo i file; i commit avvengono dopo review esplicita del developer (vedi `wm-plan` → `execution: review-gate`).
+
+**Goal:** Persistere la modalità auto/manuale del layer (`configuration->track_mode`/`poi_mode`) su entrambi i repo (wm-package + camminiditalia), correggendo l'ordine di scrittura rispetto al ricalcolo da tassonomia e la concorrenza di scrittura sulla colonna JSON condivisa.
+
+**Architecture:** Un nuovo metodo `protected persistMode()` in `wm-package`'s `LayerFeatureController` centralizza la persistenza, chiamato sia dal `sync()` del package sia dall'override locale di camminiditalia (che non delega a `parent::sync()` per motivi di ownership — oc:8311). La scrittura vera e propria (`Layer::setTrackMode()`/`setPoiMode()`) usa `jsonb_set` in un singolo `UPDATE` SQL atomico, non un read-modify-write PHP, per evitare lost-update tra i due pannelli Nova (Tracce/POI) che scrivono sulla stessa colonna. Il frontend Vue invia il flag di modalità mode-only (senza `features`) sul verso auto→manuale, perché il pivot `layerables` contiene già la selezione corretta dall'ultima sincronizzazione automatica.
+
+**Tech Stack:** Laravel 11, Nova 5, PostgreSQL/PostGIS (colonna `configuration` tipo `jsonb`), Vue 3 + TypeScript compilato con Laravel Mix, PHPUnit su DB `camminiditalia_testing`, ambiente Docker (`laravel-camminiditalia`).
+
+**Spec:**
+- `docs/features/8314-modalita-auto-manuale-layer-non-persistita/overview.md` (camminiditalia)
+- `wm-package/docs/features/8314-modalita-auto-manuale-layer-non-persistita/overview.md` (wm-package)
+
+## Global Constraints
+
+- Tutti i comandi `php artisan`/`vendor/bin/*` vanno eseguiti dentro il container: `docker exec laravel-camminiditalia <comando>`.
+- I test PHPUnit girano su `camminiditalia_testing`, DB separato — `RefreshDatabase` è sicuro (non tocca dati di sviluppo).
+- **Tutti** i test PHP di questa feature vanno in `tests/Feature/LayerFeatureControllerTest.php` nel repo principale, **mai** in `wm-package/tests/` — precedente oc:8140: `Wm\WmPackage\Tests\TestCase` non è in `autoload-dev` di camminiditalia.
+- `EcPoi::factory()->create()` richiede sempre `'properties' => []` esplicito, altrimenti `AbstractObserver` lancia `TypeError` (trappola nota, oc:8120).
+- Nessuna modifica al comportamento distruttivo di `auto: true` (sovrascrive selezione manuale) — intenzionale, preesistente, presidiato da `ConfirmModal` lato Vue.
+- Nessuna modifica a `getFeatures()` (né package né locale) — fuori scope, comportamento visibile già corretto perché le checkbox sono disabilitate lato Vue in base a `isManual`.
+- Nessuna modifica a `LayerObserver::hasTaxonomyActivitiesChanged()` — il side-effect cross-relazione discusso in overview è un rischio accettato, non un bug da correggere in questo ciclo.
+- Formattazione: `docker exec laravel-camminiditalia composer format` (Laravel Pint) prima di ogni commit; se tocca file del submodule, ripristinare modifiche non intenzionali con `git -C wm-package checkout -- .` per i soli file non voluti.
+- `has_phpstan_ci: true` — eseguire `docker exec laravel-camminiditalia vendor/bin/phpstan analyse` prima del commit finale.
+
+---
+
+## File Structure
+
+**wm-package (submodule):**
+
+| File | Responsabilità |
+|---|---|
+| `src/Models/Layer.php` | `setTrackMode()`/`setPoiMode()`: scrittura atomica via `jsonb_set`, invece del read-modify-write PHP attuale |
+| `src/Nova/Fields/LayerFeatures/src/Http/Controllers/LayerFeatureController.php` | Nuovo `protected persistMode()`; `sync()`: validazione `manual`/`auto` mutuamente esclusivi, chiamata a `persistMode()` prima di qualunque assign/sync sul pivot |
+| `src/Nova/Fields/LayerFeatures/resources/js/composables/useFeatures.ts` | `handleSave`: aggiunge `manual: true` al payload esistente |
+| `src/Nova/Fields/LayerFeatures/resources/js/components/LayerFeature.vue` | `handleToggleClick`: nuova chiamata POST mode-only sul verso auto→manuale |
+| `src/Nova/Fields/LayerFeatures/dist/*` | Rebuild via `npm run prod` |
+
+**camminiditalia (repo principale):**
+
+| File | Responsabilità |
+|---|---|
+| `app/Http/Controllers/LayerFeatureController.php` | `sync()`: stessa validazione mutuamente esclusiva, chiamata a `persistMode()` ereditato, nessuna duplicazione di logica |
+| `tests/Feature/LayerFeatureControllerTest.php` | Tutti i test della feature (7 casi, vedi Task 1 e Task 3) |
+| gitlink `wm-package` | Aggiornato al nuovo commit del submodule dopo il commit lì |
+
+---
+
+## Task 1: `Layer::setTrackMode()`/`setPoiMode()` — scrittura atomica con `jsonb_set`
+
+**Files:**
+- Modify: `wm-package/src/Models/Layer.php:158-176`
+- Test: `tests/Feature/LayerFeatureControllerTest.php` (repo principale)
+
+**Interfaces:**
+- Consumes: nessuna dipendenza da task precedenti (primo task)
+- Produces: `Layer::setTrackMode(string $mode): void`, `Layer::setPoiMode(string $mode): void` — firma invariata, usate da Task 3 (`persistMode()`)
+
+- [ ] **Step 1: Scrivi i test falliti in `tests/Feature/LayerFeatureControllerTest.php`**
+
+Apri il file esistente e aggiungi in fondo alla classe (o al blocco di test più affine, es. vicino ai test esistenti su `sync`):
+
+```php
+    public function test_set_track_mode_persists_value_and_preserves_other_configuration_keys(): void
+    {
+        $layer = Layer::factory()->create([
+            'configuration' => ['some_other_key' => 'kept'],
+        ]);
+
+        $layer->setTrackMode('manual');
+
+        $fresh = $layer->fresh();
+        $this->assertSame('manual', $fresh->configuration['track_mode']);
+        $this->assertSame('kept', $fresh->configuration['some_other_key']);
+    }
+
+    public function test_set_track_mode_accepts_null_configuration(): void
+    {
+        $layer = Layer::factory()->create(['configuration' => null]);
+
+        $layer->setTrackMode('manual');
+
+        $fresh = $layer->fresh();
+        $this->assertSame('manual', $fresh->configuration['track_mode']);
+    }
+
+    public function test_set_track_mode_and_set_poi_mode_do_not_lose_each_other_under_concurrent_writes(): void
+    {
+        $layer = Layer::factory()->create(['configuration' => null]);
+
+        // Simula due richieste concorrenti: due istanze caricate PRIMA che
+        // una delle due scriva, come accadrebbe con due pannelli Nova
+        // (Tracce e POI) sulla stessa pagina che POSTano quasi in contemporanea.
+        $layerFromRequestA = Layer::find($layer->id);
+        $layerFromRequestB = Layer::find($layer->id);
+
+        $layerFromRequestA->setTrackMode('manual');
+        $layerFromRequestB->setPoiMode('manual');
+
+        $fresh = $layer->fresh();
+        $this->assertSame('manual', $fresh->configuration['track_mode']);
+        $this->assertSame('manual', $fresh->configuration['poi_mode']);
+    }
+```
+
+Verifica che il file importi già `use Wm\WmPackage\Models\Layer;` (dovrebbe già esserci, controllane la presenza in cima al file e aggiungila se manca).
+
+- [ ] **Step 2: Esegui i test e verifica che falliscano**
+
+```bash
+docker exec laravel-camminiditalia php artisan test --filter=test_set_track_mode_persists_value_and_preserves_other_configuration_keys
+docker exec laravel-camminiditalia php artisan test --filter=test_set_track_mode_accepts_null_configuration
+docker exec laravel-camminiditalia php artisan test --filter=test_set_track_mode_and_set_poi_mode_do_not_lose_each_other_under_concurrent_writes
+```
+
+Expected: i primi due FALLISCONO con `Undefined array key "track_mode"` (perché `setTrackMode` oggi non scrive `configuration`... verifica: in realtà l'implementazione attuale FA scrivere `configuration['track_mode']`, ma con un read-modify-write PHP — quindi i primi due test potrebbero già passare con il codice attuale). Il terzo test (concorrenza) deve FALLIRE con l'implementazione attuale: `$fresh->configuration['track_mode']` risulterà `null`/assente, perché `$layerFromRequestB` ha letto `configuration` prima della scrittura di A e la sua `save()` sovrascrive l'intero blob perdendo `track_mode`.
+
+Se i primi due test passano già con l'implementazione corrente, va bene — servono comunque come test di non-regressione per la riscrittura del Task successivo. Il terzo test è quello che deve necessariamente fallire ora.
+
+- [ ] **Step 3: Riscrivi `setTrackMode()`/`setPoiMode()` con `jsonb_set`**
+
+Apri `wm-package/src/Models/Layer.php`. Verifica che in cima al file sia già importato `use Illuminate\Support\Facades\DB;` (se manca, aggiungilo agli `use` esistenti). Sostituisci le righe 158-176:
+
+```php
+    public function isAutoTrackMode(): bool
+    {
+        return ($this->configuration['track_mode'] ?? 'auto') === 'auto';
+    }
+
+    public function setTrackMode(string $mode): void
+    {
+        DB::statement(
+            "UPDATE layers SET configuration = jsonb_set(coalesce(configuration, '{}'::jsonb), '{track_mode}', to_jsonb(?::text)) WHERE id = ?",
+            [$mode, $this->id]
+        );
+
+        $this->refresh();
+    }
+
+    public function isAutoPoiMode(): bool
+    {
+        return ($this->configuration['poi_mode'] ?? 'auto') === 'auto';
+    }
+
+    public function setPoiMode(string $mode): void
+    {
+        DB::statement(
+            "UPDATE layers SET configuration = jsonb_set(coalesce(configuration, '{}'::jsonb), '{poi_mode}', to_jsonb(?::text)) WHERE id = ?",
+            [$mode, $this->id]
+        );
+
+        $this->refresh();
+    }
+```
+
+Nota: `DB::statement` con placeholder `?` usa i binding parametrizzati di PDO — nessuna concatenazione di stringhe, nessun rischio di SQL injection anche se `$mode` provenisse da input utente non validato.
+
+- [ ] **Step 4: Esegui i test e verifica che passino**
+
+```bash
+docker exec laravel-camminiditalia php artisan test --filter=LayerFeatureControllerTest
+```
+
+Expected: PASS su tutti e tre i nuovi test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C wm-package add src/Models/Layer.php
+git -C wm-package commit -m "fix(oc:8314): scrittura atomica di track_mode/poi_mode con jsonb_set"
+
+git add tests/Feature/LayerFeatureControllerTest.php
+git commit -m "test(oc:8314): verifica persistenza atomica di track_mode/poi_mode"
+```
+
+---
+
+## Task 2: Verifica stato submodule e aggiornamento gitlink preliminare
+
+**Files:**
+- Nessun file di codice modificato in questo task — solo verifica ambiente e allineamento gitlink dopo il Task 1
+
+**Interfaces:**
+- Consumes: commit di Task 1 già presente in `wm-package` (branch `develop` locale del submodule)
+- Produces: gitlink del repo principale allineato, base pulita per i task successivi
+
+- [ ] **Step 1: Verifica che il submodule sia su un branch reale, non detached HEAD**
+
+```bash
+git -C wm-package branch --show-current
+```
+
+Expected: `develop`. Se vuoto (detached HEAD), risolvi prima di continuare:
+
+```bash
+git -C wm-package checkout develop
+git -C wm-package pull origin develop
+```
+
+- [ ] **Step 2: Verifica che il commit del Task 1 sia registrato**
+
+```bash
+git -C wm-package log --oneline -1
+```
+
+Expected: mostra il commit `fix(oc:8314): scrittura atomica di track_mode/poi_mode con jsonb_set`.
+
+- [ ] **Step 3: Aggiorna il gitlink nel repo principale**
+
+```bash
+git status wm-package
+```
+
+Expected: mostra `wm-package` come modificato (il gitlink punta al nuovo commit). Non fare `git add` ancora — il gitlink verrà incluso nel commit finale dopo tutti i task su wm-package, per evitare commit intermedi con stato incoerente tra i due repo.
+
+- [ ] **Step 4: Nessun commit in questo task**
+
+Questo task è di sola verifica — si passa direttamente al Task 3.
+
+---
+
+## Task 3: `persistMode()` nel controller del package + integrazione nell'override locale
+
+**Files:**
+- Modify: `wm-package/src/Nova/Fields/LayerFeatures/src/Http/Controllers/LayerFeatureController.php`
+- Modify: `app/Http/Controllers/LayerFeatureController.php` (repo principale)
+- Test: `tests/Feature/LayerFeatureControllerTest.php` (repo principale)
+
+**Interfaces:**
+- Consumes: `Layer::setTrackMode(string $mode): void`, `Layer::setPoiMode(string $mode): void` (da Task 1)
+- Produces: `protected function persistMode(Layer $layer, string $relationName, Request $request): void` — usato solo internamente dalle due classi `sync()`, nessun altro task lo consuma direttamente
+
+**Nota sulla verifica via HTTP:** la route `POST /nova-vendor/layer-features/sync/{layerId}` è servita, su camminiditalia, **esclusivamente** dal controller locale (verificato con `php artisan route:list --path=layer-features` — l'override in `NovaServiceProvider` vince su quella del package). I test HTTP di questo task esercitano quindi sempre il controller locale, che a sua volta chiama `persistMode()` ereditato dal package: un solo giro di test copre entrambe le implementazioni.
+
+- [ ] **Step 1: Scrivi i test falliti in `tests/Feature/LayerFeatureControllerTest.php`**
+
+Aggiungi (adatta i nomi delle factory/route esistenti nel file al pattern già in uso — verifica come gli altri test del file autenticano l'utente e costruiscono il layer, es. `actingAs`, `Layer::factory()->for($user)`, ecc., e replica lo stesso pattern):
+
+```php
+    public function test_sync_with_manual_true_persists_manual_mode_for_tracks(): void
+    {
+        $owner = User::factory()->create();
+        $layer = Layer::factory()->create(['user_id' => $owner->id]);
+        $track = EcTrack::factory()->create(['user_id' => $owner->id]);
+        $layer->ecTracks()->sync([$track->id]);
+
+        $this->actingAs($owner)
+            ->postJson("/nova-vendor/layer-features/sync/{$layer->id}", [
+                'model' => EcTrack::class,
+                'manual' => true,
+            ])
+            ->assertOk();
+
+        $this->assertSame('manual', $layer->fresh()->configuration['track_mode']);
+    }
+
+    public function test_sync_with_auto_true_persists_auto_mode_explicitly(): void
+    {
+        $owner = User::factory()->create();
+        $layer = Layer::factory()->create([
+            'user_id' => $owner->id,
+            'configuration' => ['track_mode' => 'manual'],
+        ]);
+
+        $this->actingAs($owner)
+            ->postJson("/nova-vendor/layer-features/sync/{$layer->id}", [
+                'model' => EcTrack::class,
+                'auto' => true,
+                'features' => [],
+            ])
+            ->assertOk();
+
+        $this->assertSame('auto', $layer->fresh()->configuration['track_mode']);
+    }
+
+    public function test_sync_with_manual_true_and_no_features_does_not_touch_pivot(): void
+    {
+        $owner = User::factory()->create();
+        $layer = Layer::factory()->create(['user_id' => $owner->id]);
+        $trackA = EcTrack::factory()->create(['user_id' => $owner->id]);
+        $trackB = EcTrack::factory()->create(['user_id' => $owner->id]);
+        $layer->ecTracks()->sync([$trackA->id, $trackB->id]);
+
+        $this->actingAs($owner)
+            ->postJson("/nova-vendor/layer-features/sync/{$layer->id}", [
+                'model' => EcTrack::class,
+                'manual' => true,
+            ])
+            ->assertOk();
+
+        $this->assertEqualsCanonicalizing(
+            [$trackA->id, $trackB->id],
+            $layer->fresh()->ecTracks()->pluck('ec_tracks.id')->toArray()
+        );
+    }
+
+    public function test_sync_rejects_auto_and_manual_together(): void
+    {
+        $owner = User::factory()->create();
+        $layer = Layer::factory()->create(['user_id' => $owner->id]);
+
+        $this->actingAs($owner)
+            ->postJson("/nova-vendor/layer-features/sync/{$layer->id}", [
+                'model' => EcTrack::class,
+                'auto' => true,
+                'manual' => true,
+            ])
+            ->assertStatus(422);
+
+        $this->assertNull($layer->fresh()->configuration['track_mode'] ?? null);
+    }
+```
+
+Nota: adatta i nomi dei parametri di autenticazione/autorizzazione (`$owner`, il controllo `403`) al pattern reale già usato negli altri test del file — leggi i test esistenti in `LayerFeatureControllerTest.php` prima di scrivere questi per allinearti a factory e helper già presenti (es. se il file usa già un trait per l'autenticazione admin, riusalo).
+
+- [ ] **Step 2: Esegui i test e verifica che falliscano**
+
+```bash
+docker exec laravel-camminiditalia php artisan test --filter=LayerFeatureControllerTest
+```
+
+Expected: i 4 nuovi test FALLISCONO — `manual` non è un parametro validato/gestito, `configuration` resta vuota dopo la richiesta, e la richiesta con `auto`+`manual` insieme non produce 422 (nessuna regola `prohibits` esiste ancora).
+
+- [ ] **Step 3: Implementa `persistMode()` e aggiorna `sync()` nel controller del package**
+
+Apri `wm-package/src/Nova/Fields/LayerFeatures/src/Http/Controllers/LayerFeatureController.php`. Sostituisci il metodo `sync()` esistente con:
+
+```php
+    public function sync(Request $request, $layerId): JsonResponse
+    {
+        $layer = Layer::findOrFail($layerId);
+
+        $validatedData = $request->validate([
+            'features' => 'array',
+            'model' => 'required|string',
+            'auto' => ['boolean', 'prohibits:manual'],
+            'manual' => ['boolean', 'prohibits:auto'],
+        ]);
+
+        // Creo un'istanza del modello per ottenere il nome della relazione
+        $model = new $validatedData['model'];
+
+        if (! method_exists($model, 'getLayerRelationName')) {
+            return response()->json([
+                'error' => "Il modello '{$validatedData['model']}' non implementa l'interfaccia LayerRelatedModel.",
+            ], 400);
+        }
+
+        $relationName = $model->getLayerRelationName();
+
+        if (! method_exists($layer, $relationName)) {
+            return response()->json([
+                'error' => "La relazione '{$relationName}' non esiste nel modello Layer.",
+            ], 400);
+        }
+
+        $this->persistMode($layer, $relationName, $request);
+
+        $isAutoRequest = ! empty($validatedData['auto']) && in_array($relationName, ['ecTracks', 'ecPois']);
+        if ($isAutoRequest) {
+            // In modalità automatica il pivot ecTracks/ecPois viene ricalcolato da taxonomy
+            if ($relationName === 'ecTracks') {
+                $this->layerService->assignTracksByTaxonomy($layer);
+            } else {
+                $this->layerService->assignPoisByTaxonomy($layer);
+            }
+        } elseif ($request->has('features')) {
+            $layer->{$relationName}()->sync($validatedData['features'] ?? []);
+        }
+        // Nessun 'auto', nessun 'features': richiesta mode-only, il pivot non viene toccato.
+
+        // I PBF non contengono mai contenuto POI: rigenerarli ha senso solo per ecTracks.
+        if ($relationName === 'ecTracks') {
+            $this->pbfGeneratorService->regeneratePbfsForLayer($layer);
+        }
+
+        $tableName = $model->getTable();
+        $assignedIds = $layer->{$relationName}()->select($tableName.'.id')->pluck('id')->toArray();
+
+        return response()->json([
+            'message' => 'Features sincronizzate con successo',
+            'assigned_ids' => $assignedIds,
+        ], 200);
+    }
+
+    /**
+     * Persiste la modalità (auto/manuale) sul layer per la relazione indicata.
+     * Non contiene logica di autorizzazione né di calcolo degli ID selezionati:
+     * resta utilizzabile da sottoclassi che riscrivono sync() con regole di
+     * ownership proprie senza delegare a parent::sync() (es. camminiditalia).
+     *
+     * Va chiamato PRIMA di qualunque assign/sync sul pivot: assignTracksByTaxonomy()/
+     * assignPoisByTaxonomy() leggono isAutoTrackMode()/isAutoPoiMode() e devono
+     * vedere il valore già aggiornato, altrimenti il ricalcolo da tassonomia
+     * viene bloccato dal guard sulla modalità precedente.
+     */
+    protected function persistMode(Layer $layer, string $relationName, Request $request): void
+    {
+        if ($request->boolean('manual')) {
+            $mode = 'manual';
+        } elseif ($request->boolean('auto')) {
+            $mode = 'auto';
+        } else {
+            return;
+        }
+
+        if ($relationName === 'ecTracks') {
+            $layer->setTrackMode($mode);
+        } elseif ($relationName === 'ecPois') {
+            $layer->setPoiMode($mode);
+        }
+    }
+```
+
+- [ ] **Step 4: Aggiorna il controller locale in camminiditalia**
+
+Apri `app/Http/Controllers/LayerFeatureController.php`. Nel metodo `sync()`, sostituisci il blocco di validazione:
+
+```php
+            $validatedData = $request->validate([
+                'features' => 'array',
+                'model' => 'required|string',
+                'auto' => 'boolean',
+            ]);
+```
+
+con:
+
+```php
+            $validatedData = $request->validate([
+                'features' => 'array',
+                'model' => 'required|string',
+                'auto' => ['boolean', 'prohibits:manual'],
+                'manual' => ['boolean', 'prohibits:auto'],
+            ]);
+```
+
+Poi, subito dopo il controllo `if (! method_exists($layer, $relationName)) { ... }` e prima del calcolo di `$isAutoRequest`, aggiungi la chiamata:
+
+```php
+            $this->persistMode($layer, $relationName, $request);
+
+            $isAutoRequest = ! empty($validatedData['auto']) && in_array($relationName, ['ecTracks', 'ecPois']);
+
+            if ($isAutoRequest) {
+                $ownedIds = $model->newQuery()->where('user_id', $layerOwnerId)->pluck('id')->toArray();
+
+                $layer->{$relationName}()->sync($ownedIds);
+            } elseif ($request->has('features')) {
+                $requestedIds = $validatedData['features'] ?? [];
+
+                $ownedIds = $model->newQuery()->whereIn('id', $requestedIds)->where('user_id', $layerOwnerId)->pluck('id')->toArray();
+
+                $layer->{$relationName}()->sync($ownedIds);
+            }
+```
+
+(sostituisce l'attuale blocco `if ($isAutoRequest) { ... } else { ... }` che oggi esegue sempre `sync()` sul pivot anche nel ramo manuale senza `features`).
+
+`persistMode()` è ereditato da `WmLayerFeatureController` (la classe base importata come `use Wm\WmPackage\Nova\Fields\LayerFeatures\Http\Controllers\LayerFeatureController as WmLayerFeatureController;`, già presente in cima al file) — nessun nuovo `use` necessario perché è un metodo `protected`, accessibile dalla sottoclasse.
+
+- [ ] **Step 5: Esegui i test e verifica che passino**
+
+```bash
+docker exec laravel-camminiditalia php artisan test --filter=LayerFeatureControllerTest
+```
+
+Expected: PASS su tutti i test del file (i 3 di Task 1 + i 4 di questo task).
+
+- [ ] **Step 6: Esegui l'intera suite per verificare l'assenza di regressioni**
+
+```bash
+docker exec laravel-camminiditalia php artisan test
+```
+
+Expected: tutti i test passano (nessuna regressione sui test esistenti di `LayerFeatureControllerTest`, `LayerActionsVisibilityTest`, `LayerOwnershipTransferTest`, ecc.).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C wm-package add src/Nova/Fields/LayerFeatures/src/Http/Controllers/LayerFeatureController.php
+git -C wm-package commit -m "feat(oc:8314): persistMode() e validazione manual/auto mutuamente esclusivi in sync()"
+
+git add app/Http/Controllers/LayerFeatureController.php tests/Feature/LayerFeatureControllerTest.php
+git commit -m "feat(oc:8314): persisti la modalita auto/manuale nel controller locale"
+```
+
+---
+
+## Task 4: Frontend Vue — invio del flag di modalità
+
+**Files:**
+- Modify: `wm-package/src/Nova/Fields/LayerFeatures/resources/js/composables/useFeatures.ts`
+- Modify: `wm-package/src/Nova/Fields/LayerFeatures/resources/js/components/LayerFeature.vue`
+
+**Interfaces:**
+- Consumes: endpoint `POST /nova-vendor/layer-features/sync/{layerId}` già esistente, ora capace di accettare `manual` (Task 3)
+- Produces: nessuna interfaccia consumata da altri task — è l'ultimo anello della catena frontend→backend
+
+**Nota:** non esiste infrastruttura di test automatico per i componenti Vue in questo repo. La verifica di questo task è manuale (Step 5), da eseguire nell'ambiente Nova reale dopo il rebuild del dist (Task 5).
+
+- [ ] **Step 1: Aggiungi `manual: true` al payload di `handleSave`**
+
+Apri `wm-package/src/Nova/Fields/LayerFeatures/resources/js/composables/useFeatures.ts`. Trova `handleSave` (circa riga 195-219):
+
+```typescript
+    const handleSave = async (): Promise<void> => {
+        try {
+            isSaving.value = true;
+            const layerId = props.field.layerId;
+
+            if (!layerId) {
+                throw new Error('LayerId is required for saving');
+            }
+
+            await Nova.request().post(`/nova-vendor/layer-features/sync/${layerId}`, {
+                features: persistentSelectedIds.value,
+                model: props.field.model,
+            });
+```
+
+Modifica la chiamata `post` aggiungendo `manual: true`:
+
+```typescript
+            await Nova.request().post(`/nova-vendor/layer-features/sync/${layerId}`, {
+                features: persistentSelectedIds.value,
+                model: props.field.model,
+                manual: true,
+            });
+```
+
+Il resto della funzione (`Nova.success`, `props.field.value = ...`, `fetchFeatures()`) resta invariato.
+
+- [ ] **Step 2: Aggiungi la chiamata di persistenza mode-only in `handleToggleClick`**
+
+Apri `wm-package/src/Nova/Fields/LayerFeatures/resources/js/components/LayerFeature.vue`. Trova `handleToggleClick` (circa riga 324-338):
+
+```typescript
+        const handleToggleClick = async () => {
+            if (isManual.value && persistentSelectedIds.value.length > 0) {
+                showConfirmModal.value = true;
+            } else {
+                isManual.value = !isManual.value;
+                if (isManual.value) {
+                    try {
+                        await fetchFeatures();
+                    } catch (error) {
+                        console.error("Error during toggle mode:", error);
+                    }
+                } else {
+                    await handleModeChange();
+                }
+            }
+        };
+```
+
+Sostituiscilo con:
+
+```typescript
+        const handleToggleClick = async () => {
+            if (isManual.value && persistentSelectedIds.value.length > 0) {
+                showConfirmModal.value = true;
+            } else {
+                isManual.value = !isManual.value;
+                if (isManual.value) {
+                    await persistManualMode();
+                } else {
+                    await handleModeChange();
+                }
+            }
+        };
+
+        const persistManualMode = async () => {
+            try {
+                isSaving.value = true;
+                const layerId = props.field.layerId;
+                await Nova.request().post(
+                    `/nova-vendor/layer-features/sync/${layerId}`,
+                    {
+                        model: props.field.model,
+                        manual: true,
+                    }
+                );
+                await fetchFeatures();
+            } catch (error) {
+                console.error("Error during toggle mode:", error);
+                Nova.error("Errore durante il cambio di modalità");
+                isManual.value = false;
+            } finally {
+                isSaving.value = false;
+            }
+        };
+```
+
+Nota: la richiesta **non** include `features` — il pivot resta quello già scritto dall'ultima sincronizzazione automatica, coerentemente con il contratto mode-only implementato in Task 3. Su errore, `isManual.value` torna a `false` (stato precedente al click), coerente con il pattern di rollback già usato in `handleModeChange` per il verso opposto.
+
+- [ ] **Step 3: Esporta `persistManualMode` se necessario**
+
+Verifica il blocco `return { ... }` in fondo al `setup()` di `LayerFeature.vue` (circa riga 400-430): se `handleToggleClick` è già esportato e `persistManualMode` è usata solo internamente al componente, non serve esportarla. Verifica comunque che non ci siano errori di compilazione TypeScript riferiti a variabili non dichiarate.
+
+- [ ] **Step 4: Verifica manuale (nessun test automatico disponibile)**
+
+Questo step si esegue dopo il Task 5 (rebuild dist), in ambiente Nova reale:
+
+1. Apri un layer in Nova, pannello "Ec Tracks", verifica che sia in modalità "auto" con delle tracce associate.
+2. Clicca il toggle per passare a "manuale".
+3. Apri gli strumenti sviluppatore del browser, tab Network: verifica che sia partita una richiesta `POST /nova-vendor/layer-features/sync/{id}` con payload `{ model: "...", manual: true }` (nessun campo `features`).
+4. Ricarica la pagina: il toggle deve mostrare ancora "manuale" (non deve tornare su "auto").
+5. Verifica che le tracce precedentemente associate in auto siano ancora nella lista "selezionate" del pannello manuale.
+
+Documenta l'esito di questa verifica in `notes.md` (Task 8).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C wm-package add src/Nova/Fields/LayerFeatures/resources/js/composables/useFeatures.ts src/Nova/Fields/LayerFeatures/resources/js/components/LayerFeature.vue
+git -C wm-package commit -m "feat(oc:8314): invia il flag di modalita al backend su toggle e salvataggio"
+```
+
+---
+
+## Task 5: Rebuild del dist compilato
+
+**Files:**
+- Modify: `wm-package/src/Nova/Fields/LayerFeatures/dist/*` (rigenerato, non scritto a mano)
+
+**Interfaces:**
+- Consumes: sorgenti TypeScript/Vue modificati in Task 4
+- Produces: asset compilati effettivamente serviti da Nova in produzione (nessun task successivo li consuma direttamente)
+
+- [ ] **Step 1: Esegui il rebuild**
+
+```bash
+cd wm-package/src/Nova/Fields/LayerFeatures
+npm install
+npm run prod
+cd -
+```
+
+Se il comando va eseguito dentro un container invece che sull'host, verifica il `package.json` del campo per lo script `prod` e adatta il comando di conseguenza (es. `docker exec laravel-camminiditalia npm run prod --prefix wm-package/src/Nova/Fields/LayerFeatures`), mantenendo `npm run prod` come script effettivo — non `npm run build` (decisione registrata in oc:8089, Laravel Mix).
+
+- [ ] **Step 2: Verifica che il dist sia effettivamente cambiato**
+
+```bash
+git -C wm-package status --porcelain -- src/Nova/Fields/LayerFeatures/dist/
+```
+
+Expected: elenco di file modificati sotto `dist/` (almeno `mix-manifest.json` e i bundle JS). Se l'output è vuoto, il rebuild non ha prodotto modifiche — verifica di aver salvato i file di Task 4 prima di eseguire `npm run prod`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C wm-package add src/Nova/Fields/LayerFeatures/dist/
+git -C wm-package commit -m "chore(oc:8314): rebuild dist campo LayerFeatures"
+```
+
+---
+
+## Task 6: Aggiornamento gitlink finale nel repo principale
+
+**Files:**
+- Modify: gitlink `wm-package` (repo principale)
+
+**Interfaces:**
+- Consumes: tutti i commit di wm-package (Task 1, 3, 4, 5)
+- Produces: repo principale allineato al submodule aggiornato, base per Task 7
+
+- [ ] **Step 1: Verifica il log dei commit del submodule**
+
+```bash
+git -C wm-package log --oneline -5
+```
+
+Expected: mostra in cima, nell'ordine, i commit di Task 5 (rebuild dist), Task 4 (frontend), Task 3 (persistMode), Task 1 (jsonb_set) — verifica che nessuno manchi.
+
+- [ ] **Step 2: Verifica il diff del gitlink**
+
+```bash
+git diff --submodule=short -- wm-package
+```
+
+Expected: mostra l'avanzamento da `db707c8a` al nuovo HEAD del submodule.
+
+- [ ] **Step 3: Push del submodule (se il developer conferma)**
+
+Questo step **non va eseguito automaticamente**. È un'istruzione per il developer, da eseguire solo dopo la sua review esplicita del diff:
+
+```bash
+git -C wm-package push origin develop
+```
+
+- [ ] **Step 4: Stage del gitlink**
+
+```bash
+git add wm-package
+```
+
+Nessun commit qui — il gitlink verrà incluso nel commit finale insieme al resto delle modifiche del repo principale (Task 7), per avere un'unica unità di commit coerente lato camminiditalia.
+
+---
+
+## Task 7: Verifica finale e suite completa
+
+**Files:**
+- Nessuna modifica di codice — solo verifica
+
+**Interfaces:**
+- Consumes: tutto quanto prodotto dai task precedenti
+
+- [ ] **Step 1: Esegui l'intera suite PHPUnit**
+
+```bash
+docker exec laravel-camminiditalia php artisan test
+```
+
+Expected: tutti i test passano, incluse le 7 nuove asserzioni di questa feature (3 di Task 1 + 4 di Task 3).
+
+- [ ] **Step 2: Esegui Pint**
+
+```bash
+docker exec laravel-camminiditalia composer format
+```
+
+Se questo comando tocca file dentro `wm-package/` in modo non intenzionale, ripristina con:
+
+```bash
+git -C wm-package checkout -- .
+```
+
+lasciando solo le modifiche volute dei task precedenti.
+
+- [ ] **Step 3: Esegui PHPStan**
+
+```bash
+docker exec laravel-camminiditalia vendor/bin/phpstan analyse
+```
+
+Expected: nessun nuovo errore sui file toccati da questa feature (`app/Http/Controllers/LayerFeatureController.php`, `tests/Feature/LayerFeatureControllerTest.php`). Eventuali errori preesistenti su file non toccati non bloccano — segui `wm-plan → review-gate: phpstan-check` per la gestione.
+
+- [ ] **Step 4: Verifica manuale end-to-end (se non già fatta in Task 4)**
+
+Ripeti la checklist dello Step 4 di Task 4 in ambiente Nova reale, e verifica in aggiunta:
+1. Il ritorno da "manuale" ad "auto" tramite `ConfirmModal` funziona come prima (comportamento distruttivo invariato, fuori scope).
+2. Un layer con `configuration` mai scritta prima (stato di produzione) si comporta correttamente al primo toggle.
+
+- [ ] **Step 5: Nessun commit — questo task è di sola verifica**
+
+Se emergono problemi, torna al task pertinente per correggerli prima di procedere alla `Fase: notes` e ai commit finali (gestiti dal workflow `wm-plan`, non da questo piano).
+
+---
+
+## Self-Review (svolta durante la scrittura di questo piano)
+
+**Copertura requisiti overview → task:**
+
+| Requisito | Task |
+|---|---|
+| `manual`/`auto` mutuamente esclusivi (422) | Task 3 |
+| `persistMode()` protected, riusabile senza `parent::sync()` | Task 3 |
+| Persistenza esplicita di `manual` e `auto` | Task 3 |
+| Nessuna modifica se né `auto` né `manual` presenti | Task 3 (validazione `boolean` opzionale, `persistMode` fa `return` se nessuno dei due) |
+| Ordine `persistMode()` prima dell'assign da tassonomia | Task 3, Step 3 (chiamata prima del blocco `if ($isAutoRequest)`) |
+| Toggle auto→manuale mode-only, nessun `features` | Task 4 |
+| Backend non tocca il pivot su richiesta mode-only | Task 3, Step 3 (`elseif ($request->has('features'))`) |
+| `handleSave` invia `manual: true` | Task 4, Step 1 |
+| `handleModeChange` continua a inviare `auto: true` | Invariato, nessuna modifica necessaria (verificato in overview) |
+| Rollback UI su errore di persistenza | Task 4, Step 2 (`persistManualMode` catch → `isManual.value = false`) |
+| Merge non distruttivo di `configuration` | Task 1 (`jsonb_set` modifica solo la chiave indicata) |
+| `configuration` NULL gestita | Task 1 |
+| `jsonb_set` invece di read-modify-write, concorrenza | Task 1 |
+| `refresh()` dopo la scrittura | Task 1, Step 3 |
+| Rebuild dist | Task 5 |
+| Filtro ownership invariato | Task 3, Step 4 (nessuna modifica al blocco di autorizzazione esistente) |
+| Test 1-7 (overview camminiditalia) | Task 1 (test 4,5,7) + Task 3 (test 1,2,3,6) |
+| Gitlink aggiornato | Task 2 (verifica) + Task 6 (aggiornamento) |
+
+Nessun gap rilevato.
+
+**Scan placeholder:** nessun "TBD"/"implement later"/step senza codice — verificato manualmente riga per riga durante la stesura.
+
+**Coerenza dei tipi/nomi:** `persistMode(Layer $layer, string $relationName, Request $request): void` usato identico in Task 3 Step 3 (package) e Step 4 (locale, ereditato); `setTrackMode(string $mode): void`/`setPoiMode(string $mode): void` invariati da Task 1 a Task 3.

--- a/tests/Feature/LayerFeatureControllerTest.php
+++ b/tests/Feature/LayerFeatureControllerTest.php
@@ -388,4 +388,229 @@ class LayerFeatureControllerTest extends TestCase
         $this->assertContains($ownPoi->id, $assignedIds);
         $this->assertNotContains($poiOfOtherOrphanOwner->id, $assignedIds);
     }
+
+    public function test_set_track_mode_persists_value_and_preserves_other_configuration_keys(): void
+    {
+        $layer = Layer::factory()->create([
+            'configuration' => ['some_other_key' => 'kept'],
+        ]);
+
+        $layer->setTrackMode('manual');
+
+        $fresh = $layer->fresh();
+        $this->assertSame('manual', $fresh->configuration['track_mode']);
+        $this->assertSame('kept', $fresh->configuration['some_other_key']);
+    }
+
+    public function test_set_track_mode_accepts_null_configuration(): void
+    {
+        $layer = Layer::factory()->create(['configuration' => null]);
+
+        $layer->setTrackMode('manual');
+
+        $fresh = $layer->fresh();
+        $this->assertSame('manual', $fresh->configuration['track_mode']);
+    }
+
+    public function test_layer_without_configuration_defaults_to_manual_mode_on_camminiditalia(): void
+    {
+        $layer = Layer::factory()->create(['configuration' => null]);
+
+        $this->assertFalse($layer->isAutoTrackMode());
+        $this->assertFalse($layer->isAutoPoiMode());
+    }
+
+    public function test_set_track_mode_and_set_poi_mode_do_not_lose_each_other_under_concurrent_writes(): void
+    {
+        $layer = Layer::factory()->create(['configuration' => null]);
+
+        // Simula due richieste concorrenti: due istanze caricate PRIMA che
+        // una delle due scriva, come accadrebbe con due pannelli Nova
+        // (Tracce e POI) sulla stessa pagina che POSTano quasi in contemporanea.
+        $layerFromRequestA = Layer::find($layer->id);
+        $layerFromRequestB = Layer::find($layer->id);
+
+        $layerFromRequestA->setTrackMode('manual');
+        $layerFromRequestB->setPoiMode('manual');
+
+        $fresh = $layer->fresh();
+        $this->assertSame('manual', $fresh->configuration['track_mode']);
+        $this->assertSame('manual', $fresh->configuration['poi_mode']);
+    }
+
+    public function test_sync_with_manual_true_persists_manual_mode_for_tracks(): void
+    {
+        Queue::fake();
+        Http::fake();
+
+        $owner = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $owner->id]);
+        $track = EcTrack::factory()->create(['user_id' => $owner->id, 'properties' => []]);
+        $layer->ecTracks()->sync([$track->id]);
+
+        $this->actingAs($owner)
+            ->postJson("/nova-vendor/layer-features/sync/{$layer->id}", [
+                'model' => EcTrack::class,
+                'manual' => true,
+            ])
+            ->assertOk();
+
+        $this->assertSame('manual', $layer->fresh()->configuration['track_mode']);
+    }
+
+    public function test_sync_with_auto_true_persists_auto_mode_explicitly(): void
+    {
+        Queue::fake();
+        Http::fake();
+
+        $owner = $this->makeUser('Validator');
+        $layer = Layer::factory()->create([
+            'user_id' => $owner->id,
+            'configuration' => ['track_mode' => 'manual'],
+        ]);
+
+        // Il pivot ecTracks resta vuoto (nessuna traccia posseduta), ma
+        // regeneratePbfsForLayer() viene comunque invocata per la relazione
+        // ecTracks: mockata come nel pattern di test_sync_ec_tracks_triggers_pbf_regeneration
+        // per evitare la dipendenza dal bounding box reale dell'App.
+        $pbfMock = \Mockery::mock(PBFGeneratorService::class);
+        $pbfMock->shouldReceive('regeneratePbfsForLayer');
+        $this->app->instance(PBFGeneratorService::class, $pbfMock);
+
+        $this->actingAs($owner)
+            ->postJson("/nova-vendor/layer-features/sync/{$layer->id}", [
+                'model' => EcTrack::class,
+                'auto' => true,
+                'features' => [],
+            ])
+            ->assertOk();
+
+        $this->assertSame('auto', $layer->fresh()->configuration['track_mode']);
+    }
+
+    public function test_sync_with_manual_true_and_no_features_does_not_touch_pivot(): void
+    {
+        Queue::fake();
+        Http::fake();
+
+        $owner = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $owner->id]);
+        $trackA = EcTrack::factory()->create(['user_id' => $owner->id, 'properties' => []]);
+        $trackB = EcTrack::factory()->create(['user_id' => $owner->id, 'properties' => []]);
+        $layer->ecTracks()->sync([$trackA->id, $trackB->id]);
+
+        $this->actingAs($owner)
+            ->postJson("/nova-vendor/layer-features/sync/{$layer->id}", [
+                'model' => EcTrack::class,
+                'manual' => true,
+            ])
+            ->assertOk();
+
+        $this->assertEqualsCanonicalizing(
+            [$trackA->id, $trackB->id],
+            $layer->fresh()->ecTracks()->pluck('ec_tracks.id')->toArray()
+        );
+    }
+
+    public function test_sync_with_manual_true_and_no_features_does_not_trigger_pbf_regeneration(): void
+    {
+        Queue::fake();
+        Http::fake();
+
+        $owner = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $owner->id]);
+        $track = EcTrack::factory()->create(['user_id' => $owner->id, 'properties' => []]);
+        $layer->ecTracks()->sync([$track->id]);
+
+        $pbfMock = \Mockery::mock(PBFGeneratorService::class);
+        $pbfMock->shouldNotReceive('regeneratePbfsForLayer');
+        $this->app->instance(PBFGeneratorService::class, $pbfMock);
+
+        $this->actingAs($owner)
+            ->postJson("/nova-vendor/layer-features/sync/{$layer->id}", [
+                'model' => EcTrack::class,
+                'manual' => true,
+            ])
+            ->assertOk();
+    }
+
+    public function test_sync_rejects_auto_and_manual_together(): void
+    {
+        $owner = $this->makeUser('Validator');
+        $layer = Layer::factory()->create(['user_id' => $owner->id]);
+
+        $this->actingAs($owner)
+            ->postJson("/nova-vendor/layer-features/sync/{$layer->id}", [
+                'model' => EcTrack::class,
+                'auto' => true,
+                'manual' => true,
+            ])
+            ->assertStatus(422);
+
+        $this->assertNull($layer->fresh()->configuration['track_mode'] ?? null);
+    }
+
+    public function test_sync_rejects_auto_true_when_layer_owner_is_administrator(): void
+    {
+        Queue::fake();
+        Http::fake();
+
+        $admin = $this->makeUser('Administrator');
+        $layer = Layer::factory()->create(['user_id' => $admin->id]);
+        $ownedTrack = EcTrack::factory()->create(['user_id' => $admin->id, 'properties' => []]);
+        // Traccia estranea, di proprietà dello stesso admin, per dimostrare che
+        // il ramo auto (se eseguito) assegnerebbe indiscriminatamente tutto il
+        // catalogo dell'admin, non solo le tracce pertinenti a questo layer.
+        EcTrack::factory()->create(['user_id' => $admin->id, 'properties' => []]);
+
+        $response = $this->actingAs($admin)
+            ->postJson("/nova-vendor/layer-features/sync/{$layer->id}", [
+                'model' => EcTrack::class,
+                'auto' => true,
+            ])
+            ->assertStatus(422);
+
+        $this->assertStringContainsString('Amministratore', $response->json('error'));
+        $this->assertNull($layer->fresh()->configuration['track_mode'] ?? null);
+        $this->assertSame([], $layer->fresh()->ecTracks()->pluck('ec_tracks.id')->toArray());
+    }
+
+    public function test_sync_rejects_auto_true_when_resolved_owner_is_administrator_via_default_owner_id(): void
+    {
+        Queue::fake();
+        Http::fake();
+
+        $admin = $this->makeUser('Administrator');
+        config(['camminiditalia.default_owner_id' => $admin->id]);
+        $layer = Layer::factory()->create(['user_id' => null]);
+
+        $this->actingAs($admin)
+            ->postJson("/nova-vendor/layer-features/sync/{$layer->id}", [
+                'model' => EcTrack::class,
+                'auto' => true,
+            ])
+            ->assertStatus(422);
+
+        $this->assertNull($layer->fresh()->configuration['track_mode'] ?? null);
+    }
+
+    public function test_sync_allows_manual_true_even_when_layer_owner_is_administrator(): void
+    {
+        Queue::fake();
+        Http::fake();
+
+        $admin = $this->makeUser('Administrator');
+        $layer = Layer::factory()->create(['user_id' => $admin->id]);
+        $track = EcTrack::factory()->create(['user_id' => $admin->id, 'properties' => []]);
+        $layer->ecTracks()->sync([$track->id]);
+
+        $this->actingAs($admin)
+            ->postJson("/nova-vendor/layer-features/sync/{$layer->id}", [
+                'model' => EcTrack::class,
+                'manual' => true,
+            ])
+            ->assertOk();
+
+        $this->assertSame('manual', $layer->fresh()->configuration['track_mode']);
+    }
 }


### PR DESCRIPTION
## Summary
- `sync()`: valida `manual`/`auto` mutuamente esclusivi, chiama `persistMode()` ereditato da wm-package
- Rifiuta con 422 esplicito `auto:true` per layer con owner Administrator (altrimenti assegnerebbe tutte le tracce/POI di sistema di sua proprietà)
- Contratto mode-only: una richiesta senza `features` non tocca il pivot né rigenera i PBF
- `DEFAULT_LAYER_MODE=manual`: su camminiditalia i layer non usano tassonomie, il default corretto è manuale (non più auto)
- Aggiorna il gitlink `wm-package` al commit già mergiato in develop (PR webmappsrl/wm-package#261)

Bug noto, non corretto in questo ciclo: 35 layer su 118 hanno tracce associate con owner diverso dal proprietario del layer, invisibili nella UI Nova per via del filtro di ownership esistente (oc:8311). Documentato in `docs/features/8314-.../notes.md`, nessuna correzione bulk sui dati.

## Test plan
- [x] `php artisan test --filter=LayerFeatureControllerTest` (29/29 PASS)
- [x] `php artisan test` (157/157 PASS, nessuna regressione)
- [x] `vendor/bin/phpstan analyse` (0 errori)
- [x] `composer format` (Pint, nessuna violazione)

🤖 Generated with [Claude Code](https://claude.com/claude-code)